### PR TITLE
Generic host support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The "builder class" approach allows specific modifications of the `EndpointConfi
 
 #### Generic host support
 
-NServiceBus endpoints can be [hosted using the generic host](https://docs.particular.net/samples/hosting/generic-host/). When using the generic host the endpoint lifecycle and configuration is controlled by the host. The following is a sample endpoint hosted using te generic host:
+NServiceBus endpoints can be [hosted using the generic host](https://docs.particular.net/samples/hosting/generic-host/). When using the generic host the endpoint lifecycle and configuration are controlled by the host. The following is a sample endpoint hosted using the generic host:
 
 <!-- snippet: basic-generic-host-endpoint -->
 <a id='snippet-basic-generic-host-endpoint'></a>
@@ -263,7 +263,7 @@ public static IHostBuilder CreateHostBuilder(string[] args, Action<EndpointConfi
 <sup><a href='/src/Snippets/GenericHostSnippets.cs#L50-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-basic-generic-host-endpoint-with-config-previewer' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
-The testing engine needs to access the endpoint configuration before it's initialized to register the needed tests behaviors. To do the creation of the `IHostBuilder` needs to be tweaked to invoke a callback delegate that the test engine will inject at tests runtime. 
+The testing engine needs to access the endpoint configuration before it's initialized to register the needed tests behaviors. The creation of the `IHostBuilder` needs to be tweaked to invoke a callback delegate that the test engine injects at tests runtime. 
 
 Finally, the endpoint can be added to the scenario using the `WithGenericHostEndpoint` configuration method:
 

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Unhandled exceptions are a sort of problem from the integration testing infrastr
     return ctx.HasFailedMessages();
 })
 ```
-<sup><a href='/src/Snippets/DoneSnippets.cs#L16-L21' title='Snippet source file'>snippet source</a> | <a href='#snippet-simple-done-condition' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/DoneSnippets.cs#L15-L20' title='Snippet source file'>snippet source</a> | <a href='#snippet-simple-done-condition' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Such a done condition has to be read as: "If there are one or more failed messages the test is done, proceed to evaulate the assertions". Obviously this is not enough. In the identified test case scenario the test is done when a saga is invoked (specifically is created, more on this later). A saga invokation can be expressed as a done condition in the following way:
@@ -340,7 +340,7 @@ Such a done condition has to be read as: "If there are one or more failed messag
     return ctx.SagaWasInvoked<ASaga>() || ctx.HasFailedMessages();
 })
 ```
-<sup><a href='/src/Snippets/DoneSnippets.cs#L27-L32' title='Snippet source file'>snippet source</a> | <a href='#snippet-complete-done-condition' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/DoneSnippets.cs#L26-L31' title='Snippet source file'>snippet source</a> | <a href='#snippet-complete-done-condition' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The integration scenario context, the `c` argument, can be "queried" to gather the status of the test, in this case the done condition is augmented to make so that the test is considered done when a saga of type `ASaga` has been invoked or there are failed messages.
@@ -356,7 +356,7 @@ In the defined callback it's possible to define one or more "when" conditions th
 var context = await Scenario.Define<IntegrationScenarioContext>()
     .WithEndpoint<MyServiceEndpoint>(builder => builder.When(session => session.Send(new AMessage())))
 ```
-<sup><a href='/src/Snippets/KickOffSnippets.cs#L15-L18' title='Snippet source file'>snippet source</a> | <a href='#snippet-kick-off-choreography' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Snippets/KickOffSnippets.cs#L13-L16' title='Snippet source file'>snippet source</a> | <a href='#snippet-kick-off-choreography' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 The above code snippet makes so that when "MyServiceEndpoint" is started `AMessage` is sent. `When` has multiple overloads (including one with a condition-parameter) to accommodate many different scenarios.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,82 @@ The "builder class" approach allows specific modifications of the `EndpointConfi
   - Otherwise (with the default retry configuration) the IntegrationTests throw a "Some failed messages were not handled by the recoverability feature."-Exception because of a fixed 30 sec timeout in the `NServiceBus.AcceptanceTests.ScenarioRunner`.
 - Cleaning up the queues via `PurgeOnStartup(true)`
 
+#### Generic host support
+
+NServiceBus endpoints can be [hosted using the generic host](https://docs.particular.net/samples/hosting/generic-host/). When using the generic host the endpoint lifecycle and configuration is controlled by the host. The following is a sample endpoint hosted using te generic host:
+
+<!-- snippet: basic-generic-host-endpoint -->
+<a id='snippet-basic-generic-host-endpoint'></a>
+```cs
+public static void Main(string[] args)
+{
+    CreateHostBuilder(args).Build().Run();
+}
+
+public static IHostBuilder CreateHostBuilder(string[] args)
+{
+    var builder = Host.CreateDefaultBuilder(args);
+    builder.UseConsoleLifetime();
+
+    builder.UseNServiceBus(ctx =>
+    {
+        var config = new EndpointConfiguration("endpoint-name");
+        config.UseTransport(new LearningTransport());
+
+        return config;
+    });
+
+    return builder;
+}
+```
+<sup><a href='/src/Snippets/GenericHostSnippets.cs#L27-L48' title='Snippet source file'>snippet source</a> | <a href='#snippet-basic-generic-host-endpoint' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+> For more information about hosting NServiceBus using the generic host refer to the [official documentation](https://docs.particular.net/samples/hosting/generic-host/). 
+
+Before using generic host hosted endpoints with `NServiceBus.IntegrationTesting`, a minor change to the above snippet is required:
+
+<!-- snippet: basic-generic-host-endpoint-with-config-previewer -->
+<a id='snippet-basic-generic-host-endpoint-with-config-previewer'></a>
+```cs
+public static IHostBuilder CreateHostBuilder(string[] args, Action<EndpointConfiguration> configPreview)
+{
+    var builder = Host.CreateDefaultBuilder(args);
+    builder.UseConsoleLifetime();
+
+    builder.UseNServiceBus(ctx =>
+    {
+        var config = new EndpointConfiguration("endpoint-name");
+        config.UseTransport(new LearningTransport());
+
+        configPreview?.Invoke(config);
+        
+        return config;
+    });
+
+    return builder;
+}
+```
+<sup><a href='/src/Snippets/GenericHostSnippets.cs#L50-L68' title='Snippet source file'>snippet source</a> | <a href='#snippet-basic-generic-host-endpoint-with-config-previewer' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+The testing engine needs to access the endpoint configuration before it's initialized to register the needed tests behaviors. To do the creation of the `IHostBuilder` needs to be tweaked to invoke a callback delegate that the test engine will inject at tests runtime. 
+
+Finally, the endpoint can be added to the scenario using the `WithGenericHostEndpoint` configuration method:
+
+<!-- snippet: with-generic-host-endpoint -->
+<a id='snippet-with-generic-host-endpoint'></a>
+```cs
+_ = await Scenario.Define<IntegrationScenarioContext>()
+    .WithGenericHostEndpoint("endpoint-name", configPreview => Program.CreateHostBuilder(new string[0], configPreview).Build())
+```
+<sup><a href='/src/Snippets/GenericHostSnippets.cs#L16-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-with-generic-host-endpoint' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Be sure to pass to the method that creates the `IHostBuilder` the provided `Action<EndpointConfiguration>` parameter. If the endpoint is not configured correctly the following exception will be raised at test time:
+
+> Endpoint \<endpointName\> is not correctly configured to be tested. Make sure to pass the EndpointConfiguration instance to the Action<EndpointConfiguration> provided by WithGenericHostEndpoint tests setup method.
+
 ### Define tests and completion criteria
 
 #### Scenario

--- a/README.source.md
+++ b/README.source.md
@@ -101,7 +101,7 @@ The "builder class" approach allows specific modifications of the `EndpointConfi
 
 #### Generic host support
 
-NServiceBus endpoints can be [hosted using the generic host](https://docs.particular.net/samples/hosting/generic-host/). When using the generic host the endpoint lifecycle and configuration is controlled by the host. The following is a sample endpoint hosted using te generic host:
+NServiceBus endpoints can be [hosted using the generic host](https://docs.particular.net/samples/hosting/generic-host/). When using the generic host the endpoint lifecycle and configuration are controlled by the host. The following is a sample endpoint hosted using the generic host:
 
 snippet: basic-generic-host-endpoint
 
@@ -111,7 +111,7 @@ Before using generic host hosted endpoints with `NServiceBus.IntegrationTesting`
 
 snippet: basic-generic-host-endpoint-with-config-previewer
 
-The testing engine needs to access the endpoint configuration before it's initialized to register the needed tests behaviors. To do the creation of the `IHostBuilder` needs to be tweaked to invoke a callback delegate that the test engine will inject at tests runtime. 
+The testing engine needs to access the endpoint configuration before it's initialized to register the needed tests behaviors. The creation of the `IHostBuilder` needs to be tweaked to invoke a callback delegate that the test engine injects at tests runtime. 
 
 Finally, the endpoint can be added to the scenario using the `WithGenericHostEndpoint` configuration method:
 

--- a/README.source.md
+++ b/README.source.md
@@ -99,6 +99,28 @@ The "builder class" approach allows specific modifications of the `EndpointConfi
   - Otherwise (with the default retry configuration) the IntegrationTests throw a "Some failed messages were not handled by the recoverability feature."-Exception because of a fixed 30 sec timeout in the `NServiceBus.AcceptanceTests.ScenarioRunner`.
 - Cleaning up the queues via `PurgeOnStartup(true)`
 
+#### Generic host support
+
+NServiceBus endpoints can be [hosted using the generic host](https://docs.particular.net/samples/hosting/generic-host/). When using the generic host the endpoint lifecycle and configuration is controlled by the host. The following is a sample endpoint hosted using te generic host:
+
+snippet: basic-generic-host-endpoint
+
+> For more information about hosting NServiceBus using the generic host refer to the [official documentation](https://docs.particular.net/samples/hosting/generic-host/). 
+
+Before using generic host hosted endpoints with `NServiceBus.IntegrationTesting`, a minor change to the above snippet is required:
+
+snippet: basic-generic-host-endpoint-with-config-previewer
+
+The testing engine needs to access the endpoint configuration before it's initialized to register the needed tests behaviors. To do the creation of the `IHostBuilder` needs to be tweaked to invoke a callback delegate that the test engine will inject at tests runtime. 
+
+Finally, the endpoint can be added to the scenario using the `WithGenericHostEndpoint` configuration method:
+
+snippet: with-generic-host-endpoint
+
+Be sure to pass to the method that creates the `IHostBuilder` the provided `Action<EndpointConfiguration>` parameter. If the endpoint is not configured correctly the following exception will be raised at test time:
+
+> Endpoint \<endpointName\> is not correctly configured to be tested. Make sure to pass the EndpointConfiguration instance to the Action<EndpointConfiguration> provided by WithGenericHostEndpoint tests setup method.
+
 ### Define tests and completion criteria
 
 #### Scenario

--- a/src/MyOtherService/MyOtherService.csproj
+++ b/src/MyOtherService/MyOtherService.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.172" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.124" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyOtherService/MyOtherService.csproj
+++ b/src/MyOtherService/MyOtherService.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.86" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.124" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.172" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyService/ASaga.cs
+++ b/src/MyService/ASaga.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using MyMessages.Messages;
 using NServiceBus;
-using Serilog;
 using System;
 using System.Threading.Tasks;
 

--- a/src/MyService/ASaga.cs
+++ b/src/MyService/ASaga.cs
@@ -1,5 +1,7 @@
-﻿using MyMessages.Messages;
+﻿using Microsoft.Extensions.Logging;
+using MyMessages.Messages;
 using NServiceBus;
+using Serilog;
 using System;
 using System.Threading.Tasks;
 
@@ -10,6 +12,11 @@ namespace MyService
         IHandleMessages<CompleteASaga>,
         IHandleTimeouts<ASaga.MyTimeout>
     {
+        public ASaga(ILogger<ASaga> logger)
+        {
+            logger.LogInformation("ASaga instance created successfully");
+        }
+
         public Task Handle(StartASaga message, IMessageHandlerContext context)
         {
             return RequestTimeout<MyTimeout>(context, DateTime.UtcNow.AddDays(10));

--- a/src/MyService/MyService.csproj
+++ b/src/MyService/MyService.csproj
@@ -12,6 +12,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.19" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
     <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.124" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.1.2" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyService/MyService.csproj
+++ b/src/MyService/MyService.csproj
@@ -7,9 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.86" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.124" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.0.0-alpha.144" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.19" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.202" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyService/MyService.csproj
+++ b/src/MyService/MyService.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.0.0-alpha.144" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.19" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.202" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.172" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyService/MyService.csproj
+++ b/src/MyService/MyService.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.0.0-alpha.144" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.19" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.172" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="7.0.0-alpha.124" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MyService/MyServiceConfiguration.cs
+++ b/src/MyService/MyServiceConfiguration.cs
@@ -3,7 +3,7 @@ using NServiceBus;
 
 namespace MyService
 {
-    public class MyServiceConfiguration : EndpointConfiguration
+    class MyServiceConfiguration : EndpointConfiguration
     {
         public MyServiceConfiguration()
             : base("MyService")

--- a/src/MyService/Program.cs
+++ b/src/MyService/Program.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using MyService;
 using NServiceBus;
+using Serilog;
 
 namespace MyService
 {
@@ -17,6 +17,11 @@ namespace MyService
         {
             var builder = Host.CreateDefaultBuilder(args);
             builder.UseConsoleLifetime();
+            
+            builder.UseSerilog((context, services, loggerConfiguration) => loggerConfiguration
+                    .ReadFrom.Configuration(context.Configuration)
+                    .Enrich.FromLogContext()
+                    .WriteTo.Console());
 
             builder.ConfigureLogging((ctx, logging) =>
             {

--- a/src/MyService/Program.cs
+++ b/src/MyService/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using NServiceBus;
 using Serilog;
 
@@ -22,12 +21,6 @@ namespace MyService
                     .ReadFrom.Configuration(context.Configuration)
                     .Enrich.FromLogContext()
                     .WriteTo.Console());
-
-            builder.ConfigureLogging((ctx, logging) =>
-            {
-                logging.AddConfiguration(ctx.Configuration.GetSection("Logging"));
-                logging.AddConsole();
-            });
 
             builder.UseNServiceBus(ctx =>
             {

--- a/src/MyService/Program.cs
+++ b/src/MyService/Program.cs
@@ -1,22 +1,31 @@
-﻿using NServiceBus;
-using System;
-using System.Threading.Tasks;
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using MyService;
+using NServiceBus;
 
 namespace MyService
 {
-    class Program
+    public class Program
     {
-        static async Task Main(string[] args)
+        public static void Main(string[] args)
         {
-            Console.Title = typeof(Program).Namespace;
+            CreateHostBuilder(args).Build().Run();
+        }
 
-            var endpointConfiguration = new MyServiceConfiguration();
-            var endpointInstance = await Endpoint.Start(endpointConfiguration);
+        public static IHostBuilder CreateHostBuilder(string[] args)
+        {
+            var builder = Host.CreateDefaultBuilder(args);
+            builder.UseConsoleLifetime();
 
-            Console.WriteLine($"{typeof(Program).Namespace} started. Press any key to stop.");
-            Console.ReadLine();
+            builder.ConfigureLogging((ctx, logging) =>
+            {
+                logging.AddConfiguration(ctx.Configuration.GetSection("Logging"));
+                logging.AddConsole();
+            });
 
-            await endpointInstance.Stop();
+            builder.UseNServiceBus(ctx => new MyServiceConfiguration());
+
+            return builder;
         }
     }
 }

--- a/src/MyService/Program.cs
+++ b/src/MyService/Program.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Hosting;
+﻿using System;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using MyService;
 using NServiceBus;
@@ -12,7 +13,7 @@ namespace MyService
             CreateHostBuilder(args).Build().Run();
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args)
+        public static IHostBuilder CreateHostBuilder(string[] args, Action<EndpointConfiguration> configPreview = null)
         {
             var builder = Host.CreateDefaultBuilder(args);
             builder.UseConsoleLifetime();
@@ -23,7 +24,13 @@ namespace MyService
                 logging.AddConsole();
             });
 
-            builder.UseNServiceBus(ctx => new MyServiceConfiguration());
+            builder.UseNServiceBus(ctx =>
+            {
+                var config = new MyServiceConfiguration();
+                configPreview?.Invoke(config);
+
+                return config;
+            });
 
             return builder;
         }

--- a/src/MySystem.AcceptanceTests/MySystem.AcceptanceTests.csproj
+++ b/src/MySystem.AcceptanceTests/MySystem.AcceptanceTests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.842" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1898" />
     <PackageReference Include="SimpleExec" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/MySystem.AcceptanceTests/MySystem.AcceptanceTests.csproj
+++ b/src/MySystem.AcceptanceTests/MySystem.AcceptanceTests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1898" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
     <PackageReference Include="SimpleExec" Version="8.0.0" />
   </ItemGroup>
 

--- a/src/MySystem.AcceptanceTests/When_requesting_a_timeout.cs
+++ b/src/MySystem.AcceptanceTests/When_requesting_a_timeout.cs
@@ -32,7 +32,7 @@ namespace MySystem.AcceptanceTests
             {
                 ctx.RegisterTimeoutRescheduleRule<ASaga.MyTimeout>((msg, delay) => new DoNotDeliverBefore(DateTime.UtcNow.AddSeconds(5)));
             })
-            .WithGenericHostEndpoint("MyService", () => Program.CreateHostBuilder(new string[0]).Build(), behavior =>
+                .WithGenericHostEndpoint("MyService", configPreview => Program.CreateHostBuilder(new string[0], configPreview).Build(), behavior =>
             {
                 behavior.When(session => session.Send("MyService", new StartASaga() {AnIdentifier = Guid.NewGuid()}));
             })
@@ -42,14 +42,6 @@ namespace MySystem.AcceptanceTests
             Assert.True(context.MessageWasProcessedBySaga<ASaga.MyTimeout, ASaga>());
             Assert.False(context.HasFailedMessages());
             Assert.False(context.HasHandlingErrors());
-        }
-
-        class MyServiceEndpoint : EndpointConfigurationBuilder
-        {
-            public MyServiceEndpoint()
-            {
-                EndpointSetup<EndpointTemplate<MyServiceConfiguration>>();
-            }
         }
     }
 }

--- a/src/MySystem.AcceptanceTests/When_requesting_a_timeout.cs
+++ b/src/MySystem.AcceptanceTests/When_requesting_a_timeout.cs
@@ -32,7 +32,7 @@ namespace MySystem.AcceptanceTests
             {
                 ctx.RegisterTimeoutRescheduleRule<ASaga.MyTimeout>((msg, delay) => new DoNotDeliverBefore(DateTime.UtcNow.AddSeconds(5)));
             })
-            .WithEndpoint<MyServiceEndpoint>(behavior =>
+            .WithGenericHostEndpoint("MyService", () => Program.CreateHostBuilder(new string[0]).Build(), behavior =>
             {
                 behavior.When(session => session.Send("MyService", new StartASaga() {AnIdentifier = Guid.NewGuid()}));
             })

--- a/src/MySystem.AcceptanceTests/When_sending_AMessage.cs
+++ b/src/MySystem.AcceptanceTests/When_sending_AMessage.cs
@@ -1,5 +1,4 @@
 using MyMessages.Messages;
-using MyOtherService;
 using MyService;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting;

--- a/src/MySystem.AcceptanceTests/When_sending_AMessage.cs
+++ b/src/MySystem.AcceptanceTests/When_sending_AMessage.cs
@@ -31,7 +31,7 @@ namespace MySystem.AcceptanceTests
         {
             var theExpectedIdentifier = Guid.NewGuid();
             var context = await Scenario.Define<IntegrationScenarioContext>()
-                .WithEndpoint<MyServiceEndpoint>(behavior =>
+                .WithGenericHostEndpoint("MyService", configPreview => Program.CreateHostBuilder(new string[0], configPreview).Build(), behavior =>
                 {
                     behavior.When(session => session.Send(new AMessage() {AnIdentifier = theExpectedIdentifier}));
                 })
@@ -46,14 +46,6 @@ namespace MySystem.AcceptanceTests
             Assert.True(((ASagaData)invokedSaga.SagaData).AnIdentifier == theExpectedIdentifier);
             Assert.False(context.HasFailedMessages());
             Assert.False(context.HasHandlingErrors());
-        }
-
-        class MyServiceEndpoint : EndpointConfigurationBuilder
-        {
-            public MyServiceEndpoint()
-            {
-                EndpointSetup<EndpointTemplate<MyServiceConfiguration>>();
-            }
         }
 
         class MyOtherServiceEndpoint : EndpointConfigurationBuilder

--- a/src/MySystem.AcceptanceTests/When_sending_CompleteASaga.cs
+++ b/src/MySystem.AcceptanceTests/When_sending_CompleteASaga.cs
@@ -30,7 +30,7 @@ namespace MySystem.AcceptanceTests
         {
             var theExpectedIdentifier = Guid.NewGuid();
             var context = await Scenario.Define<IntegrationScenarioContext>()
-                .WithEndpoint<MyServiceEndpoint>(behavior =>
+                .WithGenericHostEndpoint("MyService", configPreview => Program.CreateHostBuilder(new string[0], configPreview).Build(), behavior =>
                 {
                     behavior.When(session =>
                     {
@@ -39,7 +39,7 @@ namespace MySystem.AcceptanceTests
                     behavior.When(condition: ctx =>
                     {
                         return ctx.SagaWasInvoked<ASaga>() && ctx.InvokedSagas.Any(s=> s.SagaType == typeof(ASaga) && s.IsNew);
-                    }, 
+                    },
                     action: session =>
                     {
                         return session.Send("MyService", new CompleteASaga {AnIdentifier = theExpectedIdentifier});
@@ -59,14 +59,6 @@ namespace MySystem.AcceptanceTests
             Assert.IsNotNull(completedSaga);
             Assert.False(context.HasFailedMessages());
             Assert.False(context.HasHandlingErrors());
-        }
-
-        class MyServiceEndpoint : EndpointConfigurationBuilder
-        {
-            public MyServiceEndpoint()
-            {
-                EndpointSetup<EndpointTemplate<MyServiceConfiguration>>();
-            }
         }
     }
 }

--- a/src/NServiceBus.AssemblyScanner.Extensions/NServiceBus.AssemblyScanner.Extensions.csproj
+++ b/src/NServiceBus.AssemblyScanner.Extensions/NServiceBus.AssemblyScanner.Extensions.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.IntegrationTesting.Tests.TestEndpoint/NServiceBus.IntegrationTesting.Tests.TestEndpoint.csproj
+++ b/src/NServiceBus.IntegrationTesting.Tests.TestEndpoint/NServiceBus.IntegrationTesting.Tests.TestEndpoint.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.4.4" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
+    <PackageReference Include="NServiceBus.RabbitMQ" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MyMessages\MyMessages.csproj" />
+    <ProjectReference Include="..\NServiceBus.AssemblyScanner.Extensions\NServiceBus.AssemblyScanner.Extensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.IntegrationTesting.Tests.TestEndpoint/NServiceBus.IntegrationTesting.Tests.TestEndpoint.csproj
+++ b/src/NServiceBus.IntegrationTesting.Tests.TestEndpoint/NServiceBus.IntegrationTesting.Tests.TestEndpoint.csproj
@@ -7,10 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="7.4.4" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="1.1.0" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
-    <PackageReference Include="NServiceBus.RabbitMQ" Version="6.0.0" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="2.0.0-alpha.144" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.IntegrationTesting.Tests.TestEndpoint/Program.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests.TestEndpoint/Program.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Hosting;
+
+namespace NServiceBus.IntegrationTesting.Tests.TestEndpoint
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args)
+        {
+            var builder = Host.CreateDefaultBuilder(args);
+            builder.UseConsoleLifetime();
+
+            builder.UseNServiceBus(ctx =>
+            {
+                var config = new EndpointConfiguration("NServiceBus.IntegrationTesting.Tests.TestEndpoint");
+                config.UseTransport<LearningTransport>();
+
+                config.AssemblyScanner().ExcludeAssemblies("NServiceBus.IntegrationTesting.Tests.dll");
+
+                return config;
+            });
+
+            return builder;
+        }
+    }
+}

--- a/src/NServiceBus.IntegrationTesting.Tests.TestEndpoint/Program.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests.TestEndpoint/Program.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.IntegrationTesting.Tests.TestEndpoint
             builder.UseNServiceBus(ctx =>
             {
                 var config = new EndpointConfiguration("NServiceBus.IntegrationTesting.Tests.TestEndpoint");
-                config.UseTransport<LearningTransport>();
+                config.UseTransport(new LearningTransport());
 
                 config.AssemblyScanner().ExcludeAssemblies("NServiceBus.IntegrationTesting.Tests.dll");
 

--- a/src/NServiceBus.IntegrationTesting.Tests/API/APIApprovals.Approve_API.approved.txt
+++ b/src/NServiceBus.IntegrationTesting.Tests/API/APIApprovals.Approve_API.approved.txt
@@ -32,6 +32,18 @@ namespace NServiceBus.IntegrationTesting
         public EndpointTemplate() { }
         protected override System.Threading.Tasks.Task<NServiceBus.EndpointConfiguration> OnGetConfiguration(NServiceBus.AcceptanceTesting.Support.RunDescriptor runDescriptor, NServiceBus.AcceptanceTesting.Support.EndpointCustomizationConfiguration endpointConfiguration, System.Action<NServiceBus.EndpointConfiguration> configurationBuilderCustomization) { }
     }
+    public class GenericHostEndpointBehaviorBuilder<TContext>
+        where TContext : NServiceBus.AcceptanceTesting.ScenarioContext
+    {
+        public GenericHostEndpointBehaviorBuilder() { }
+        public System.Collections.Generic.IList<NServiceBus.AcceptanceTesting.Support.IWhenDefinition> Whens { get; }
+        public NServiceBus.IntegrationTesting.GenericHostEndpointBehaviorBuilder<TContext> When(System.Func<NServiceBus.IMessageSession, System.Threading.Tasks.Task> action) { }
+        public NServiceBus.IntegrationTesting.GenericHostEndpointBehaviorBuilder<TContext> When(System.Func<NServiceBus.IMessageSession, TContext, System.Threading.Tasks.Task> action) { }
+        public NServiceBus.IntegrationTesting.GenericHostEndpointBehaviorBuilder<TContext> When(System.Func<TContext, System.Threading.Tasks.Task<bool>> condition, System.Func<NServiceBus.IMessageSession, System.Threading.Tasks.Task> action) { }
+        public NServiceBus.IntegrationTesting.GenericHostEndpointBehaviorBuilder<TContext> When(System.Func<TContext, System.Threading.Tasks.Task<bool>> condition, System.Func<NServiceBus.IMessageSession, TContext, System.Threading.Tasks.Task> action) { }
+        public NServiceBus.IntegrationTesting.GenericHostEndpointBehaviorBuilder<TContext> When(System.Predicate<TContext> condition, System.Func<NServiceBus.IMessageSession, System.Threading.Tasks.Task> action) { }
+        public NServiceBus.IntegrationTesting.GenericHostEndpointBehaviorBuilder<TContext> When(System.Predicate<TContext> condition, System.Func<NServiceBus.IMessageSession, TContext, System.Threading.Tasks.Task> action) { }
+    }
     public class HandlerInvocation : NServiceBus.IntegrationTesting.Invocation
     {
         public HandlerInvocation() { }
@@ -99,6 +111,11 @@ namespace NServiceBus.IntegrationTesting
         public bool NotFound { get; }
         public NServiceBus.IContainSagaData SagaData { get; }
         public System.Type SagaType { get; }
+    }
+    public static class ScenarioWithEndpointBehaviorExtensions
+    {
+        public static NServiceBus.AcceptanceTesting.Support.IScenarioWithEndpointBehavior<TContext> WithGenericHostEndpoint<TContext>(this NServiceBus.AcceptanceTesting.Support.IScenarioWithEndpointBehavior<TContext> scenarioWithEndpoint, string endpointName, System.Func<System.Action<NServiceBus.EndpointConfiguration>, Microsoft.Extensions.Hosting.IHost> hostBuilder, System.Action<NServiceBus.IntegrationTesting.GenericHostEndpointBehaviorBuilder<TContext>> behavior = null)
+            where TContext : NServiceBus.AcceptanceTesting.ScenarioContext { }
     }
     public class SendOperation : NServiceBus.IntegrationTesting.OutgoingMessageOperation
     {

--- a/src/NServiceBus.IntegrationTesting.Tests/API/ApiApprovals.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/API/ApiApprovals.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using ApprovalTests;
 using ApprovalTests.Reporters;
-using NServiceBus.IntegrationTesting;
 using NUnit.Framework;
 using PublicApiGenerator;
 

--- a/src/NServiceBus.IntegrationTesting.Tests/NServiceBus.IntegrationTesting.Tests.csproj
+++ b/src/NServiceBus.IntegrationTesting.Tests/NServiceBus.IntegrationTesting.Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MyMessages\MyMessages.csproj" />
+    <ProjectReference Include="..\NServiceBus.IntegrationTesting.Tests.TestEndpoint\NServiceBus.IntegrationTesting.Tests.TestEndpoint.csproj" />
     <ProjectReference Include="..\NServiceBus.IntegrationTesting\NServiceBus.IntegrationTesting.csproj" />
   </ItemGroup>
 

--- a/src/NServiceBus.IntegrationTesting.Tests/Publish_Operation_Interceptor.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/Publish_Operation_Interceptor.cs
@@ -2,7 +2,6 @@
 using NServiceBus.Pipeline;
 using NServiceBus.Testing;
 using NUnit.Framework;
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/NServiceBus.IntegrationTesting.Tests/Reply_Operation_Interceptor.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/Reply_Operation_Interceptor.cs
@@ -2,7 +2,6 @@
 using NServiceBus.Pipeline;
 using NServiceBus.Testing;
 using NUnit.Framework;
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/NServiceBus.IntegrationTesting.Tests/Reschedule_Timeout_Behavior.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/Reschedule_Timeout_Behavior.cs
@@ -1,12 +1,9 @@
 ﻿using MyMessages.Messages;
 using NServiceBus.DelayedDelivery;
-using NServiceBus.DeliveryConstraints;
 using NServiceBus.Pipeline;
 using NServiceBus.Testing;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.Transport;
 

--- a/src/NServiceBus.IntegrationTesting.Tests/Send_Operation_Interceptor.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/Send_Operation_Interceptor.cs
@@ -1,11 +1,7 @@
 ﻿using MyMessages.Messages;
-using NServiceBus.DelayedDelivery;
-using NServiceBus.DeliveryConstraints;
 using NServiceBus.Pipeline;
 using NServiceBus.Testing;
 using NUnit.Framework;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/NServiceBus.IntegrationTesting.Tests/When_capturing_handlers_invocations.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/When_capturing_handlers_invocations.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace NServiceBus.IntegrationTesting.Tests

--- a/src/NServiceBus.IntegrationTesting.Tests/When_capturing_sagas_invocations.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/When_capturing_sagas_invocations.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace NServiceBus.IntegrationTesting.Tests

--- a/src/NServiceBus.IntegrationTesting.Tests/When_using_generic_host.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/When_using_generic_host.cs
@@ -1,0 +1,31 @@
+using NServiceBus.AcceptanceTesting;
+using NUnit.Framework;
+using System;
+using NServiceBus.IntegrationTesting.Tests.TestEndpoint;
+
+namespace NServiceBus.IntegrationTesting.Tests
+{
+    public class When_using_generic_host
+    {
+        [Test]
+        public void Ensure_endpoint_is_correctly_configured()
+        {
+            var endpointName = "NServiceBus.IntegrationTesting.Tests.TestEndpoint";
+            var expectedMessage = $"Endpoint {endpointName} is not correctly configured to be tested. " +
+                $"Make sure to pass the EndpointConfiguration instance to the Action<EndpointConfiguration> " +
+                $"provided by WithGenericHostEndpoint tests setup method.";
+
+            var ex = _ = Assert.ThrowsAsync<Exception>(async () =>
+            {
+                await Scenario.Define<IntegrationScenarioContext>()
+                    .WithGenericHostEndpoint(
+                        endpointName,
+                        configPreview => Program.CreateHostBuilder(new string[0]).Build(),
+                        _ => { })
+                    .Run();
+            });
+
+            Assert.AreEqual(expectedMessage, ex.Message);
+        }
+    }
+}

--- a/src/NServiceBus.IntegrationTesting.sln
+++ b/src/NServiceBus.IntegrationTesting.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.IntegrationTest
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Snippets", "Snippets\Snippets.csproj", "{927BC675-5940-43C6-BB97-96DA64CBA6D0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.IntegrationTesting.Tests.TestEndpoint", "NServiceBus.IntegrationTesting.Tests.TestEndpoint\NServiceBus.IntegrationTesting.Tests.TestEndpoint.csproj", "{A830D9C2-07D2-49F3-996A-9AE9EE85B38B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -57,6 +59,10 @@ Global
 		{927BC675-5940-43C6-BB97-96DA64CBA6D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{927BC675-5940-43C6-BB97-96DA64CBA6D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{927BC675-5940-43C6-BB97-96DA64CBA6D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A830D9C2-07D2-49F3-996A-9AE9EE85B38B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A830D9C2-07D2-49F3-996A-9AE9EE85B38B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A830D9C2-07D2-49F3-996A-9AE9EE85B38B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A830D9C2-07D2-49F3-996A-9AE9EE85B38B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NServiceBus.IntegrationTesting/EnsureEndpointIsConfiguredForTests.cs
+++ b/src/NServiceBus.IntegrationTesting/EnsureEndpointIsConfiguredForTests.cs
@@ -1,0 +1,4 @@
+namespace NServiceBus.IntegrationTesting
+{
+    class EnsureEndpointIsConfiguredForTests{ }
+}

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehavior.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehavior.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NServiceBus.AcceptanceTesting.Support;
+
+namespace NServiceBus.IntegrationTesting
+{
+    public class GenericHostEndpointBehavior : IComponentBehavior
+    {
+        readonly Func<IHost> hostBuilder;
+        readonly IList<IWhenDefinition> whens;
+        readonly string endpointName;
+
+        public GenericHostEndpointBehavior(string endpointName, Func<IHost> hostBuilder, IList<IWhenDefinition> whens)
+        {
+            this.endpointName = endpointName;
+            this.hostBuilder = hostBuilder;
+            this.whens = whens;
+        }
+
+        public Task<ComponentRunner> CreateRunner(RunDescriptor run)
+        {
+            var host = hostBuilder();
+            var runner = new GenericHostEndpointRunner(run, endpointName, host, whens);
+            return Task.FromResult((ComponentRunner)runner);
+        }
+    }
+}

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehavior.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehavior.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using NServiceBus.AcceptanceTesting.Support;
 
@@ -25,7 +26,7 @@ namespace NServiceBus.IntegrationTesting
             {
                 configuration.RegisterRequiredPipelineBehaviors(endpointName, (IntegrationScenarioContext)runDescriptor.ScenarioContext);
                 configuration.RegisterScenarioContext(runDescriptor.ScenarioContext);
-                configuration.RegisterComponents(r => { r.RegisterSingleton(new EnsureEndpointIsConfiguredForTests()); });
+                configuration.RegisterComponents(r => { r.AddSingleton<EnsureEndpointIsConfiguredForTests>(); });
             });
             var runner = new GenericHostEndpointRunner(runDescriptor, endpointName, host, whens);
             return Task.FromResult((ComponentRunner)runner);

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehavior.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehavior.cs
@@ -25,6 +25,7 @@ namespace NServiceBus.IntegrationTesting
             {
                 configuration.RegisterRequiredPipelineBehaviors(endpointName, (IntegrationScenarioContext)runDescriptor.ScenarioContext);
                 configuration.RegisterScenarioContext(runDescriptor.ScenarioContext);
+                configuration.RegisterComponents(r => { r.RegisterSingleton(new EnsureEndpointIsConfiguredForTests()); });
             });
             var runner = new GenericHostEndpointRunner(runDescriptor, endpointName, host, whens);
             return Task.FromResult((ComponentRunner)runner);

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehavior.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehavior.cs
@@ -6,7 +6,7 @@ using NServiceBus.AcceptanceTesting.Support;
 
 namespace NServiceBus.IntegrationTesting
 {
-    public class GenericHostEndpointBehavior : IComponentBehavior
+    class GenericHostEndpointBehavior : IComponentBehavior
     {
         readonly Func<IHost> hostBuilder;
         readonly IList<IWhenDefinition> whens;

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehaviorBuilder.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTesting.Support;
+
+namespace NServiceBus.IntegrationTesting
+{
+    public class GenericHostEndpointBehaviorBuilder<TContext> where TContext : ScenarioContext
+    {
+        public GenericHostEndpointBehaviorBuilder<TContext> When(Func<IMessageSession, TContext, Task> action)
+        {
+            return When(c => true, action);
+        }
+
+        public GenericHostEndpointBehaviorBuilder<TContext> When(Func<IMessageSession, Task> action)
+        {
+            return When(c => true, action);
+        }
+
+        public GenericHostEndpointBehaviorBuilder<TContext> When(Func<TContext, Task<bool>> condition, Func<IMessageSession, Task> action)
+        {
+            Whens.Add(new WhenDefinition<TContext>(condition, action));
+
+            return this;
+        }
+
+        public GenericHostEndpointBehaviorBuilder<TContext> When(Predicate<TContext> condition, Func<IMessageSession, Task> action)
+        {
+            Whens.Add(new WhenDefinition<TContext>(ctx => Task.FromResult(condition(ctx)), action));
+
+            return this;
+        }
+
+        public GenericHostEndpointBehaviorBuilder<TContext> When(Func<TContext, Task<bool>> condition, Func<IMessageSession, TContext, Task> action)
+        {
+            Whens.Add(new WhenDefinition<TContext>(condition, action));
+
+            return this;
+        }
+
+        public GenericHostEndpointBehaviorBuilder<TContext> When(Predicate<TContext> condition, Func<IMessageSession, TContext, Task> action)
+        {
+            Whens.Add(new WhenDefinition<TContext>(ctx => Task.FromResult(condition(ctx)), action));
+
+            return this;
+        }
+
+        public IList<IWhenDefinition> Whens { get; } = new List<IWhenDefinition>();
+    }
+}

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointBehaviorBuilder.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
-using NServiceBus;
 using NServiceBus.AcceptanceTesting;
 using NServiceBus.AcceptanceTesting.Support;
 

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointRunner.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointRunner.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NServiceBus.AcceptanceTesting;
 using NServiceBus.AcceptanceTesting.Support;
 using NServiceBus.Logging;
 

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointRunner.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointRunner.cs
@@ -14,14 +14,14 @@ namespace NServiceBus.IntegrationTesting
     class GenericHostEndpointRunner : ComponentRunner
     {
         static ILog Logger = LogManager.GetLogger<EndpointRunner>();
-        readonly RunDescriptor run;
+        readonly RunDescriptor runDescriptor;
         readonly IHost host;
         readonly IList<IWhenDefinition> whens;
 
-        public GenericHostEndpointRunner(RunDescriptor run, string endpointName, IHost host, IList<IWhenDefinition> whens)
+        public GenericHostEndpointRunner(RunDescriptor runDescriptor, string endpointName, IHost host, IList<IWhenDefinition> whens)
         {
             Name = endpointName;
-            this.run = run;
+            this.runDescriptor = runDescriptor;
             this.host = host;
             this.whens = whens;
         }
@@ -68,7 +68,7 @@ namespace NServiceBus.IntegrationTesting
                                     continue;
                                 }
 
-                                if (await when.ExecuteAction(run.ScenarioContext, messageSession).ConfigureAwait(false))
+                                if (await when.ExecuteAction(runDescriptor.ScenarioContext, messageSession).ConfigureAwait(false))
                                 {
                                     executedWhens.Add(when.Id);
                                 }
@@ -106,9 +106,9 @@ namespace NServiceBus.IntegrationTesting
 
         void ThrowOnFailedMessages()
         {
-            foreach (var failedMessage in run.ScenarioContext.FailedMessages.Where(kvp => kvp.Key == Name))
+            foreach (var failedMessage in runDescriptor.ScenarioContext.FailedMessages.Where(kvp => kvp.Key == Name))
             {
-                throw new MessageFailedException(failedMessage.Value.First(), run.ScenarioContext);
+                throw new MessageFailedException(failedMessage.Value.First(), runDescriptor.ScenarioContext);
             }
         }
     }

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointRunner.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointRunner.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTesting.Support;
+using NServiceBus.Logging;
+
+namespace NServiceBus.IntegrationTesting
+{
+    class GenericHostEndpointRunner : ComponentRunner
+    {
+        static ILog Logger = LogManager.GetLogger<EndpointRunner>();
+        readonly RunDescriptor run;
+        readonly IHost host;
+        readonly IList<IWhenDefinition> whens;
+
+        public GenericHostEndpointRunner(RunDescriptor run, string endpointName, IHost host, IList<IWhenDefinition> whens)
+        {
+            Name = endpointName;
+            this.run = run;
+            this.host = host;
+            this.whens = whens;
+        }
+
+        public override string Name { get; }
+
+        public override async Task Start(CancellationToken token)
+        {
+            await host.StartAsync(token);
+
+            var messageSession = host.Services.GetRequiredService<IMessageSession>();
+
+            //TODO: How to access ScenarioContext.CurrentEndpoint
+            // ScenarioContext.CurrentEndpoint = Name;
+            try
+            {
+                if (whens.Count != 0)
+                {
+                    await Task.Run(async () =>
+                    {
+                        var executedWhens = new HashSet<Guid>();
+
+                        while (!token.IsCancellationRequested)
+                        {
+                            if (executedWhens.Count == whens.Count)
+                            {
+                                break;
+                            }
+
+                            if (token.IsCancellationRequested)
+                            {
+                                break;
+                            }
+
+                            foreach (var when in whens)
+                            {
+                                if (token.IsCancellationRequested)
+                                {
+                                    break;
+                                }
+
+                                if (executedWhens.Contains(when.Id))
+                                {
+                                    continue;
+                                }
+
+                                if (await when.ExecuteAction(run.ScenarioContext, messageSession).ConfigureAwait(false))
+                                {
+                                    executedWhens.Add(when.Id);
+                                }
+                            }
+
+                            await Task.Yield(); // enforce yield current context, tight loop could introduce starvation
+                        }
+                    }, token).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"Failed to execute Whens on endpoint{Name}", ex);
+
+                throw;
+            }
+        }
+
+        public override async Task Stop()
+        {
+            //TODO: How to access ScenarioContext.CurrentEndpoint
+            // ScenarioContext.CurrentEndpoint = Name;
+            try
+            {
+                await host.StopAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error("Failed to stop endpoint " + Name, ex);
+                throw;
+            }
+
+            ThrowOnFailedMessages();
+        }
+
+        void ThrowOnFailedMessages()
+        {
+            foreach (var failedMessage in run.ScenarioContext.FailedMessages.Where(kvp => kvp.Key == Name))
+            {
+                throw new MessageFailedException(failedMessage.Value.First(), run.ScenarioContext);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.IntegrationTesting/GenericHostEndpointRunner.cs
+++ b/src/NServiceBus.IntegrationTesting/GenericHostEndpointRunner.cs
@@ -32,6 +32,8 @@ namespace NServiceBus.IntegrationTesting
         {
             await host.StartAsync(token);
 
+            EnsureEndpointIsConfiguredForTests();
+
             var messageSession = host.Services.GetRequiredService<IMessageSession>();
 
             //TODO: How to access ScenarioContext.CurrentEndpoint
@@ -84,6 +86,18 @@ namespace NServiceBus.IntegrationTesting
                 Logger.Error($"Failed to execute Whens on endpoint{Name}", ex);
 
                 throw;
+            }
+        }
+
+        private void EnsureEndpointIsConfiguredForTests()
+        {
+            var check = host.Services.GetService<EnsureEndpointIsConfiguredForTests>();
+            if (check == null)
+            {
+                throw new Exception($"Endpoint {Name} is not correctly configured to be tested. " +
+                                    $"Make sure to pass the EndpointConfiguration instance to the " +
+                                    $"Action<EndpointConfiguration> provided by WithGenericHostEndpoint " +
+                                    $"tests setup method.");
             }
         }
 

--- a/src/NServiceBus.IntegrationTesting/IntegrationScenarioContext.cs
+++ b/src/NServiceBus.IntegrationTesting/IntegrationScenarioContext.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 
 namespace NServiceBus.IntegrationTesting
 {

--- a/src/NServiceBus.IntegrationTesting/InterceptSendOperations.cs
+++ b/src/NServiceBus.IntegrationTesting/InterceptSendOperations.cs
@@ -1,10 +1,5 @@
-﻿using NServiceBus.DelayedDelivery;
-using NServiceBus.DeliveryConstraints;
-using NServiceBus.Pipeline;
-using NUnit.Framework;
+﻿using NServiceBus.Pipeline;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace NServiceBus.IntegrationTesting

--- a/src/NServiceBus.IntegrationTesting/NServiceBus.IntegrationTesting.csproj
+++ b/src/NServiceBus.IntegrationTesting/NServiceBus.IntegrationTesting.csproj
@@ -24,9 +24,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.19" />
-        <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
-        <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1898" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[3.1.19, 5.0.0)" />
+        <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
+        <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NServiceBus.IntegrationTesting/NServiceBus.IntegrationTesting.csproj
+++ b/src/NServiceBus.IntegrationTesting/NServiceBus.IntegrationTesting.csproj
@@ -24,8 +24,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="NServiceBus" Version="8.0.0-alpha.842" />
-        <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.842" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.19" />
+        <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
+        <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1898" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NServiceBus.IntegrationTesting/RescheduleTimeoutsBehavior.cs
+++ b/src/NServiceBus.IntegrationTesting/RescheduleTimeoutsBehavior.cs
@@ -1,9 +1,6 @@
 ﻿using NServiceBus.DelayedDelivery;
-using NServiceBus.DeliveryConstraints;
 using NServiceBus.Pipeline;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.Transport;
 

--- a/src/NServiceBus.IntegrationTesting/ScenarioWithEndpointBehaviorExtensions.cs
+++ b/src/NServiceBus.IntegrationTesting/ScenarioWithEndpointBehaviorExtensions.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.IntegrationTesting
     public static class ScenarioWithEndpointBehaviorExtensions
     {
         public static IScenarioWithEndpointBehavior<TContext> WithGenericHostEndpoint<TContext>(this IScenarioWithEndpointBehavior<TContext> scenarioWithEndpoint,
-            string endpointName, Func<IHost> hostBuilder, Action<GenericHostEndpointBehaviorBuilder<TContext>> behavior = null) where TContext : ScenarioContext
+            string endpointName, Func<Action<EndpointConfiguration>, IHost> hostBuilder, Action<GenericHostEndpointBehaviorBuilder<TContext>> behavior = null) where TContext : ScenarioContext
         {
             var behaviorBuilder = new GenericHostEndpointBehaviorBuilder<TContext>();
             behavior?.Invoke(behaviorBuilder);

--- a/src/NServiceBus.IntegrationTesting/ScenarioWithEndpointBehaviorExtensions.cs
+++ b/src/NServiceBus.IntegrationTesting/ScenarioWithEndpointBehaviorExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using Microsoft.Extensions.Hosting;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTesting.Support;
+
+namespace NServiceBus.IntegrationTesting
+{
+    public static class ScenarioWithEndpointBehaviorExtensions
+    {
+        public static IScenarioWithEndpointBehavior<TContext> WithGenericHostEndpoint<TContext>(this IScenarioWithEndpointBehavior<TContext> scenarioWithEndpoint,
+            string endpointName, Func<IHost> hostBuilder, Action<GenericHostEndpointBehaviorBuilder<TContext>> behavior = null) where TContext : ScenarioContext
+        {
+            var behaviorBuilder = new GenericHostEndpointBehaviorBuilder<TContext>();
+            behavior?.Invoke(behaviorBuilder);
+
+            scenarioWithEndpoint.WithComponent(new GenericHostEndpointBehavior(endpointName, hostBuilder, behaviorBuilder.Whens));
+
+            return scenarioWithEndpoint;
+        }
+    }
+}

--- a/src/Snippets/DoneSnippets.cs
+++ b/src/Snippets/DoneSnippets.cs
@@ -2,7 +2,6 @@
 using MyService;
 using NServiceBus.AcceptanceTesting;
 using NServiceBus.IntegrationTesting;
-using NUnit.Framework;
 
 namespace DoneSnippets
 {

--- a/src/Snippets/GenericHostSnippets.cs
+++ b/src/Snippets/GenericHostSnippets.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.IntegrationTesting;
+using NUnit.Framework;
+
+namespace GenericHostSnippets
+{
+    public class When_sending_AMessage
+    {
+        [Test]
+        public async Task AReplyMessage_is_received_and_ASaga_is_started()
+        {
+            // begin-snippet: with-generic-host-endpoint
+            _ = await Scenario.Define<IntegrationScenarioContext>()
+                .WithGenericHostEndpoint("endpoint-name", configPreview => Program.CreateHostBuilder(new string[0], configPreview).Build()) 
+            // end-snippet
+                .Done(ctx=>false)
+                .Run();
+        }
+    }
+
+    class Program
+    {
+        // begin-snippet: basic-generic-host-endpoint
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args)
+        {
+            var builder = Host.CreateDefaultBuilder(args);
+            builder.UseConsoleLifetime();
+
+            builder.UseNServiceBus(ctx =>
+            {
+                var config = new EndpointConfiguration("endpoint-name");
+                config.UseTransport(new LearningTransport());
+
+                return config;
+            });
+
+            return builder;
+        }
+        // end-snippet
+        
+        // begin-snippet: basic-generic-host-endpoint-with-config-previewer
+        public static IHostBuilder CreateHostBuilder(string[] args, Action<EndpointConfiguration> configPreview)
+        {
+            var builder = Host.CreateDefaultBuilder(args);
+            builder.UseConsoleLifetime();
+
+            builder.UseNServiceBus(ctx =>
+            {
+                var config = new EndpointConfiguration("endpoint-name");
+                config.UseTransport(new LearningTransport());
+
+                configPreview?.Invoke(config);
+                
+                return config;
+            });
+
+            return builder;
+        }
+        // end-snippet
+    }
+}

--- a/src/Snippets/KickOffSnippets.cs
+++ b/src/Snippets/KickOffSnippets.cs
@@ -1,10 +1,8 @@
 ﻿using System.Threading.Tasks;
 using MyMessages.Messages;
-using MyService;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting;
 using NServiceBus.IntegrationTesting;
-using NUnit.Framework;
 
 namespace KickOffSnippets
 {

--- a/src/Snippets/Snippets.csproj
+++ b/src/Snippets/Snippets.csproj
@@ -5,6 +5,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.19" />
+    </ItemGroup>
+    
+    <ItemGroup>
       <ProjectReference Include="..\MyOtherService\MyOtherService.csproj" />
       <ProjectReference Include="..\MyService\MyService.csproj" />
       <ProjectReference Include="..\NServiceBus.IntegrationTesting\NServiceBus.IntegrationTesting.csproj" />


### PR DESCRIPTION
This Pull Request adds support to test endpoints hosted using the .NET generic host. The acceptance testing framework, which is the base implementation for this testing toolkit, assumes full control over the endpoint and endpoint configuration lifecycles. To include generic host-hosted endpoints a new component behavior was required to plugin the new logic.

The implementation requires a hacky/weird workaround based on an extension point users must provide to allow the integration testing infrastructure to customize the endpoint configuration adding the required behaviors. When using the generic host the lifecycle of the endpoint works more or less in the following way:

1. User code creates the endpoint configuration in `UseNserviceBus(...)`
2. the configuration is used to create a startable endpoint
   - the configuration is frozen
   - the underlying IoC container is configured and frozen
3. the host starts and so the endpoint

When the testing engine gest control back it's too late to manipulate the configuration, without mentioning that it's not stored anywhere accessible so even if it was not too late the configuration is not available. The test engine needs to add behaviors that require changing the configuration and the container, but both are read-only at this point.

The `OnGetConfiguration` doesn't work either because it expects the lifecycle to be controlled by the test engine and not be the generic host. Even if I decide to stop depending on the acceptance testing framework, which sooner or later I will, I don't see anyway a different way of doing it.

- [x] forward port https://github.com/mauroservienti/NServiceBus.IntegrationTesting/pull/179/commits/b860bc1518363c12eadc09dc3acf5a9f3cd956ae from 1.1
- [x] documentation
- [x] verify Serilog setup and usage
- [x] PR documentation