### PR TITLE
feat: implement SkipRule — allow tests to ACK messages without handler invocation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ NServiceBus.IntegrationTesting. By the end you will have:
 
 - A companion `*.Testing` project for each endpoint you want to test
 - One or more named **scenarios** that send messages from inside the endpoint process
-- An NUnit test project that starts Docker containers and asserts on handler invocations, message dispatches, saga state, and failure outcomes
+- An NUnit test project that starts Docker containers and asserts on handler invocations, message dispatches, saga state, message skips, and failure outcomes
 
 > [!NOTE]
 > This guide uses NUnit, but NServiceBus.IntegrationTesting works with any unit testing framework
@@ -587,6 +587,40 @@ Assert.That(results.MessageDispatched("OrderProcessingTimeout").Intent,
     Is.EqualTo("RequestTimeout"));
 ```
 
+### Skipping messages
+
+Sometimes you want to test a scenario where a message is **not** processed — for example, verifying that when `PaymentProcessor` does not reply, an upstream saga escalates via a timeout. Use a `SkipRule` to ACK the message without invoking any handlers, and observe the skip in the test:
+
+```csharp
+// PaymentProcessor.Testing/Program.cs
+await IntegrationTestingBootstrap.RunAsync(
+    "PaymentProcessor",
+    PaymentProcessorConfig.Create,
+    scenarios: [new ProcessPaymentScenario()],
+    skipRules: [SkipRule.For<ProcessPayment>()]);
+```
+
+The message is consumed from the queue (no dead-lettering, no retries) and a `MessageSkippedEvent` is reported to the test host. Wait for it in the test:
+
+```csharp
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+var results = await _env.Observe(correlationId, cts.Token)
+    .MessageSkipped("ProcessPayment")
+    .WhenAllAsync();
+
+var skip = results.MessageSkipped("ProcessPayment");
+Assert.That(skip.EndpointName, Is.EqualTo("PaymentProcessor"));
+```
+
+You can also pass a predicate to skip only messages that meet a condition:
+
+```csharp
+skipRules: [SkipRule.For<ProcessPayment>(msg => msg.Amount > 1000)]
+```
+
+`MessageSkipped` cannot be combined with `MessageFailed` in the same `ObserveContext`.
+
 ### Predicate overloads
 
 All `HandlerInvoked`, `SagaInvoked`, and `MessageDispatched` conditions support two additional overloads that let you encode business assertions directly in the done condition — the condition fires only when the predicate on the latest event returns `true`:
@@ -1010,6 +1044,7 @@ await IntegrationTestingBootstrap.RunAsync(
     configFactory:     YourEndpointConfig.Create,
     scenarios:         [new SomeCommandScenario()],     // optional
     timeoutRules:      [TimeoutRule.For<T>(TimeSpan)],  // optional
+    skipRules:         [SkipRule.For<T>()],              // optional
     sigTermGracePeriod: TimeSpan.FromSeconds(10));       // optional, default 5 s
 ```
 
@@ -1021,4 +1056,14 @@ TimeoutRule.For<SomeTimeout>(TimeSpan.FromSeconds(5))
 
 // Compute the delay from the timeout message instance
 TimeoutRule.For<SomeTimeout>(msg => msg.CustomDelay)
+```
+
+### `SkipRule`
+
+```csharp
+// ACK all messages of type T without invoking any handlers
+SkipRule.For<ProcessPayment>()
+
+// ACK only messages of type T that satisfy the predicate
+SkipRule.For<ProcessPayment>(msg => msg.Amount > 1000)
 ```

--- a/src/NServiceBus.IntegrationTesting.Agent.v10/AgentService.cs
+++ b/src/NServiceBus.IntegrationTesting.Agent.v10/AgentService.cs
@@ -187,6 +187,22 @@ public sealed class AgentService : IAsyncDisposable
             },
             cancellationToken);
 
+    internal Task ReportMessageSkippedAsync(
+        string messageTypeName,
+        string? correlationId,
+        CancellationToken cancellationToken = default)
+        => SendAsync(
+            new AgentToHostMessage
+            {
+                MessageSkipped = new MessageSkippedMessage
+                {
+                    EndpointName = _endpointName,
+                    MessageTypeName = messageTypeName,
+                    CorrelationId = correlationId ?? string.Empty
+                }
+            },
+            cancellationToken);
+
     internal Task ReportMessageFailedAsync(
         IReadOnlyDictionary<string, string> headers,
         string exceptionMessage,

--- a/src/NServiceBus.IntegrationTesting.Agent.v10/IntegrationTestingBootstrap.cs
+++ b/src/NServiceBus.IntegrationTesting.Agent.v10/IntegrationTestingBootstrap.cs
@@ -32,6 +32,7 @@ public static class IntegrationTestingBootstrap
         Func<EndpointConfiguration> configFactory,
         IEnumerable<Scenario>? scenarios = null,
         IEnumerable<TimeoutRule>? timeoutRules = null,
+        IEnumerable<SkipRule>? skipRules = null,
         TimeSpan sigTermGracePeriod = default)
     {
         var gracePeriod = sigTermGracePeriod > TimeSpan.Zero ? sigTermGracePeriod : TimeSpan.FromSeconds(5);
@@ -64,6 +65,12 @@ public static class IntegrationTestingBootstrap
             config.Pipeline.Register(
                 new TimeoutRescheduleBehavior(rules),
                 "Shortens saga timeout delays for faster test execution");
+
+        var skips = skipRules?.ToList() ?? [];
+        if (skips.Count > 0)
+            config.Pipeline.Register(
+                new SkipMessageBehavior(skips, agentService),
+                "ACKs matching messages without invoking handlers and reports them to the test host");
 
         config.Recoverability().Failed(c => c.OnMessageSentToErrorQueue((failedMessage, ct) =>
         {

--- a/src/NServiceBus.IntegrationTesting.Agent.v10/SkipMessageBehavior.cs
+++ b/src/NServiceBus.IntegrationTesting.Agent.v10/SkipMessageBehavior.cs
@@ -1,0 +1,37 @@
+using NServiceBus.Pipeline;
+
+namespace NServiceBus.IntegrationTesting.Agent;
+
+/// <summary>
+/// Incoming pipeline behavior that checks each message against registered SkipRules.
+/// When a rule matches, the message is ACKed without invoking any handlers and a
+/// MessageSkippedMessage is reported to the test host.
+/// Registered by IntegrationTestingBootstrap when skipRules are provided.
+/// </summary>
+class SkipMessageBehavior(IReadOnlyList<SkipRule> rules, AgentService agentService)
+    : Behavior<IIncomingLogicalMessageContext>
+{
+    public override async Task Invoke(IIncomingLogicalMessageContext context, Func<Task> next)
+    {
+        var messageType = context.Message.MessageType;
+        var messageInstance = context.Message.Instance;
+        // Correlation ID was already extracted from transport headers by
+        // IncomingCorrelationIdBehavior earlier in the pipeline.
+        var correlationId = AgentService.CurrentCorrelationId.Value;
+
+        foreach (var rule in rules)
+        {
+            if (!rule.ShouldSkip(messageType, messageInstance))
+                continue;
+
+            await agentService.ReportMessageSkippedAsync(
+                messageType.AssemblyQualifiedName ?? messageType.FullName ?? messageType.Name,
+                correlationId,
+                CancellationToken.None);
+
+            return; // short-circuit — message is ACKed without calling any handlers
+        }
+
+        await next();
+    }
+}

--- a/src/NServiceBus.IntegrationTesting.Agent.v10/SkipRule.cs
+++ b/src/NServiceBus.IntegrationTesting.Agent.v10/SkipRule.cs
@@ -1,0 +1,39 @@
+namespace NServiceBus.IntegrationTesting.Agent;
+
+/// <summary>
+/// Defines a rule that causes matching incoming messages to be silently ACKed
+/// without invoking any handlers. The skip is reported to the test host as a
+/// <c>MessageSkippedEvent</c> so tests can observe it via ObserveContext.MessageSkipped().
+///
+/// Register via IntegrationTestingBootstrap.RunAsync(..., skipRules: [...]).
+///
+/// Typical use: testing saga timeout / escalation paths where a downstream endpoint
+/// must not reply, simulating an unavailable service.
+/// </summary>
+public abstract class SkipRule
+{
+    /// <summary>
+    /// Creates a rule that skips all messages of type <typeparamref name="T"/>.
+    /// </summary>
+    public static SkipRule For<T>() => new SkipRule<T>(null);
+
+    /// <summary>
+    /// Creates a rule that skips messages of type <typeparamref name="T"/> only when
+    /// <paramref name="predicate"/> returns true for the message instance.
+    /// The predicate receives the deserialized message so callers can inspect its content.
+    /// </summary>
+    public static SkipRule For<T>(Func<T, bool> predicate) => new SkipRule<T>(predicate);
+
+    internal abstract bool ShouldSkip(Type messageType, object message);
+}
+
+sealed class SkipRule<T>(Func<T, bool>? predicate) : SkipRule
+{
+    internal override bool ShouldSkip(Type messageType, object message)
+    {
+        if (messageType != typeof(T) && !messageType.IsAssignableTo(typeof(T)))
+            return false;
+
+        return predicate is null || predicate((T)message);
+    }
+}

--- a/src/NServiceBus.IntegrationTesting.Agent.v8/NServiceBus.IntegrationTesting.Agent.v8.csproj
+++ b/src/NServiceBus.IntegrationTesting.Agent.v8/NServiceBus.IntegrationTesting.Agent.v8.csproj
@@ -40,6 +40,8 @@
         <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\Scenario.cs" Link="Scenario.cs" />
         <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\TimeoutRescheduleBehavior.cs" Link="TimeoutRescheduleBehavior.cs" />
         <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\TimeoutRule.cs" Link="TimeoutRule.cs" />
+        <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\SkipMessageBehavior.cs" Link="SkipMessageBehavior.cs" />
+        <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\SkipRule.cs" Link="SkipRule.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NServiceBus.IntegrationTesting.Agent.v9/NServiceBus.IntegrationTesting.Agent.v9.csproj
+++ b/src/NServiceBus.IntegrationTesting.Agent.v9/NServiceBus.IntegrationTesting.Agent.v9.csproj
@@ -39,6 +39,8 @@
         <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\Scenario.cs" Link="Scenario.cs" />
         <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\TimeoutRescheduleBehavior.cs" Link="TimeoutRescheduleBehavior.cs" />
         <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\TimeoutRule.cs" Link="TimeoutRule.cs" />
+        <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\SkipMessageBehavior.cs" Link="SkipMessageBehavior.cs" />
+        <Compile Include="..\NServiceBus.IntegrationTesting.Agent.v10\SkipRule.cs" Link="SkipRule.cs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NServiceBus.IntegrationTesting.Tests/ObserveResultsTests.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/ObserveResultsTests.cs
@@ -14,6 +14,9 @@ public class ObserveResultsTests
     static MessageDispatchedEvent MakeDispatchEvent(string correlationId = "c1", string messageTypeName = "Msg") =>
         new(EndpointName: "EP", MessageTypeName: messageTypeName, Intent: "Send", CorrelationId: correlationId);
 
+    static MessageSkippedEvent MakeSkippedEvent(string correlationId = "c1", string messageTypeName = "Msg") =>
+        new(EndpointName: "EP", MessageTypeName: messageTypeName, CorrelationId: correlationId);
+
     // ── HandlerInvocations ────────────────────────────────────────────────────
 
     [Test]
@@ -22,6 +25,7 @@ public class ObserveResultsTests
         var evt = MakeHandlerEvent(handlerTypeName: "MyHandler");
         var results = new ObserveResults(
             new Dictionary<string, IReadOnlyList<HandlerInvokedEvent>> { ["MyHandler"] = [evt] },
+            [],
             [],
             []);
 
@@ -34,7 +38,7 @@ public class ObserveResultsTests
     [Test]
     public void HandlerInvocations_throws_when_key_missing()
     {
-        var results = new ObserveResults([], [], []);
+        var results = new ObserveResults([], [], [], []);
 
         var ex = Assert.Throws<InvalidOperationException>(
             () => results.HandlerInvocations("Missing"));
@@ -50,6 +54,7 @@ public class ObserveResultsTests
         var results = new ObserveResults(
             new Dictionary<string, IReadOnlyList<HandlerInvokedEvent>> { ["H"] = [first, last] },
             [],
+            [],
             []);
 
         Assert.That(results.HandlerInvoked("H"), Is.SameAs(last));
@@ -64,6 +69,7 @@ public class ObserveResultsTests
         var results = new ObserveResults(
             [],
             new Dictionary<string, IReadOnlyList<HandlerInvokedEvent>> { ["MySaga"] = [evt] },
+            [],
             []);
 
         var list = results.SagaInvocations("MySaga");
@@ -74,7 +80,7 @@ public class ObserveResultsTests
     [Test]
     public void SagaInvocations_throws_when_key_missing()
     {
-        var results = new ObserveResults([], [], []);
+        var results = new ObserveResults([], [], [], []);
 
         var ex = Assert.Throws<InvalidOperationException>(
             () => results.SagaInvocations("MissingSaga"));
@@ -90,6 +96,7 @@ public class ObserveResultsTests
         var results = new ObserveResults(
             new Dictionary<string, IReadOnlyList<HandlerInvokedEvent>> { ["MySaga"] = [evt] },
             [],
+            [],
             []);
 
         Assert.Throws<InvalidOperationException>(() => results.SagaInvocations("MySaga"));
@@ -103,6 +110,7 @@ public class ObserveResultsTests
         var results = new ObserveResults(
             [],
             new Dictionary<string, IReadOnlyList<HandlerInvokedEvent>> { ["S"] = [first, last] },
+            [],
             []);
 
         Assert.That(results.SagaInvoked("S"), Is.SameAs(last));
@@ -117,7 +125,8 @@ public class ObserveResultsTests
         var results = new ObserveResults(
             [],
             [],
-            new Dictionary<string, IReadOnlyList<MessageDispatchedEvent>> { ["OrderPlaced"] = [evt] });
+            new Dictionary<string, IReadOnlyList<MessageDispatchedEvent>> { ["OrderPlaced"] = [evt] },
+            []);
 
         var list = results.MessageDispatches("OrderPlaced");
 
@@ -128,7 +137,7 @@ public class ObserveResultsTests
     [Test]
     public void MessageDispatches_throws_when_key_missing()
     {
-        var results = new ObserveResults([], [], []);
+        var results = new ObserveResults([], [], [], []);
 
         var ex = Assert.Throws<InvalidOperationException>(
             () => results.MessageDispatches("Ghost"));
@@ -144,8 +153,52 @@ public class ObserveResultsTests
         var results = new ObserveResults(
             [],
             [],
-            new Dictionary<string, IReadOnlyList<MessageDispatchedEvent>> { ["M"] = [first, last] });
+            new Dictionary<string, IReadOnlyList<MessageDispatchedEvent>> { ["M"] = [first, last] },
+            []);
 
         Assert.That(results.MessageDispatched("M"), Is.SameAs(last));
+    }
+
+    // ── MessageSkips ──────────────────────────────────────────────────────────
+
+    [Test]
+    public void MessageSkips_returns_list_when_key_exists()
+    {
+        var evt = MakeSkippedEvent(messageTypeName: "PaymentRequest");
+        var results = new ObserveResults(
+            [],
+            [],
+            [],
+            new Dictionary<string, IReadOnlyList<MessageSkippedEvent>> { ["PaymentRequest"] = [evt] });
+
+        var list = results.MessageSkips("PaymentRequest");
+
+        Assert.That(list, Has.Count.EqualTo(1));
+        Assert.That(list[0], Is.SameAs(evt));
+    }
+
+    [Test]
+    public void MessageSkips_throws_when_key_missing()
+    {
+        var results = new ObserveResults([], [], [], []);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => results.MessageSkips("Ghost"));
+
+        Assert.That(ex!.Message, Does.Contain("Ghost"));
+    }
+
+    [Test]
+    public void MessageSkipped_returns_last_event()
+    {
+        var first = MakeSkippedEvent(messageTypeName: "M");
+        var last = MakeSkippedEvent(messageTypeName: "M");
+        var results = new ObserveResults(
+            [],
+            [],
+            [],
+            new Dictionary<string, IReadOnlyList<MessageSkippedEvent>> { ["M"] = [first, last] });
+
+        Assert.That(results.MessageSkipped("M"), Is.SameAs(last));
     }
 }

--- a/src/NServiceBus.IntegrationTesting.Tests/PublicApiTests.PublicApi_matches_approved_snapshot.verified.txt
+++ b/src/NServiceBus.IntegrationTesting.Tests/PublicApiTests.PublicApi_matches_approved_snapshot.verified.txt
@@ -48,6 +48,13 @@ namespace NServiceBus.IntegrationTesting
         public string CorrelationId { get; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Headers { get; }
     }
+    public sealed class MessageSkippedEvent : System.IEquatable<NServiceBus.IntegrationTesting.MessageSkippedEvent>
+    {
+        public MessageSkippedEvent(string EndpointName, string MessageTypeName, string CorrelationId) { }
+        public string CorrelationId { get; init; }
+        public string EndpointName { get; init; }
+        public string MessageTypeName { get; init; }
+    }
     public sealed class ObserveContext
     {
         public NServiceBus.IntegrationTesting.ObserveContext HandlerInvoked(string handlerTypeName) { }
@@ -57,6 +64,9 @@ namespace NServiceBus.IntegrationTesting
         public NServiceBus.IntegrationTesting.ObserveContext MessageDispatched(string messageTypeName, System.Func<NServiceBus.IntegrationTesting.MessageDispatchedEvent, bool> until) { }
         public NServiceBus.IntegrationTesting.ObserveContext MessageDispatched(string messageTypeName, System.Func<System.Collections.Generic.IReadOnlyList<NServiceBus.IntegrationTesting.MessageDispatchedEvent>, bool> until) { }
         public NServiceBus.IntegrationTesting.ObserveContext MessageFailed() { }
+        public NServiceBus.IntegrationTesting.ObserveContext MessageSkipped(string messageTypeName) { }
+        public NServiceBus.IntegrationTesting.ObserveContext MessageSkipped(string messageTypeName, System.Func<NServiceBus.IntegrationTesting.MessageSkippedEvent, bool> until) { }
+        public NServiceBus.IntegrationTesting.ObserveContext MessageSkipped(string messageTypeName, System.Func<System.Collections.Generic.IReadOnlyList<NServiceBus.IntegrationTesting.MessageSkippedEvent>, bool> until) { }
         public NServiceBus.IntegrationTesting.ObserveContext SagaInvoked(string sagaTypeName) { }
         public NServiceBus.IntegrationTesting.ObserveContext SagaInvoked(string sagaTypeName, System.Func<NServiceBus.IntegrationTesting.HandlerInvokedEvent, bool> until) { }
         public NServiceBus.IntegrationTesting.ObserveContext SagaInvoked(string sagaTypeName, System.Func<System.Collections.Generic.IReadOnlyList<NServiceBus.IntegrationTesting.HandlerInvokedEvent>, bool> until) { }
@@ -69,6 +79,8 @@ namespace NServiceBus.IntegrationTesting
         public NServiceBus.IntegrationTesting.MessageDispatchedEvent MessageDispatched(string messageTypeName) { }
         public System.Collections.Generic.IReadOnlyList<NServiceBus.IntegrationTesting.MessageDispatchedEvent> MessageDispatches(string messageTypeName) { }
         public NServiceBus.IntegrationTesting.MessageFailedEvent MessageFailed() { }
+        public NServiceBus.IntegrationTesting.MessageSkippedEvent MessageSkipped(string messageTypeName) { }
+        public System.Collections.Generic.IReadOnlyList<NServiceBus.IntegrationTesting.MessageSkippedEvent> MessageSkips(string messageTypeName) { }
         public System.Collections.Generic.IReadOnlyList<NServiceBus.IntegrationTesting.HandlerInvokedEvent> SagaInvocations(string sagaTypeName) { }
         public NServiceBus.IntegrationTesting.HandlerInvokedEvent SagaInvoked(string sagaTypeName) { }
     }
@@ -120,12 +132,14 @@ namespace NServiceBus.IntegrationTesting.Proto
         public const int HandlerInvokedFieldNumber = 2;
         public const int MessageDispatchedFieldNumber = 3;
         public const int MessageFailedFieldNumber = 4;
+        public const int MessageSkippedFieldNumber = 5;
         public AgentToHostMessage() { }
         public AgentToHostMessage(NServiceBus.IntegrationTesting.Proto.AgentToHostMessage other) { }
         public NServiceBus.IntegrationTesting.Proto.ConnectMessage Connect { get; set; }
         public NServiceBus.IntegrationTesting.Proto.HandlerInvokedMessage HandlerInvoked { get; set; }
         public NServiceBus.IntegrationTesting.Proto.MessageDispatchedMessage MessageDispatched { get; set; }
         public NServiceBus.IntegrationTesting.Proto.MessageFailedMessage MessageFailed { get; set; }
+        public NServiceBus.IntegrationTesting.Proto.MessageSkippedMessage MessageSkipped { get; set; }
         public NServiceBus.IntegrationTesting.Proto.AgentToHostMessage.PayloadOneofCase PayloadCase { get; }
         public static Google.Protobuf.Reflection.MessageDescriptor Descriptor { get; }
         public static Google.Protobuf.MessageParser<NServiceBus.IntegrationTesting.Proto.AgentToHostMessage> Parser { get; }
@@ -146,6 +160,7 @@ namespace NServiceBus.IntegrationTesting.Proto
             HandlerInvoked = 2,
             MessageDispatched = 3,
             MessageFailed = 4,
+            MessageSkipped = 5,
         }
     }
     [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
@@ -303,6 +318,29 @@ namespace NServiceBus.IntegrationTesting.Proto
         public override int GetHashCode() { }
         public void MergeFrom(Google.Protobuf.CodedInputStream input) { }
         public void MergeFrom(NServiceBus.IntegrationTesting.Proto.MessageFailedMessage other) { }
+        public override string ToString() { }
+        public void WriteTo(Google.Protobuf.CodedOutputStream output) { }
+    }
+    [System.Diagnostics.DebuggerDisplay("{ToString(),nq}")]
+    public sealed class MessageSkippedMessage : Google.Protobuf.IBufferMessage, Google.Protobuf.IDeepCloneable<NServiceBus.IntegrationTesting.Proto.MessageSkippedMessage>, Google.Protobuf.IMessage, Google.Protobuf.IMessage<NServiceBus.IntegrationTesting.Proto.MessageSkippedMessage>, System.IEquatable<NServiceBus.IntegrationTesting.Proto.MessageSkippedMessage>
+    {
+        public const int CorrelationIdFieldNumber = 3;
+        public const int EndpointNameFieldNumber = 1;
+        public const int MessageTypeNameFieldNumber = 2;
+        public MessageSkippedMessage() { }
+        public MessageSkippedMessage(NServiceBus.IntegrationTesting.Proto.MessageSkippedMessage other) { }
+        public string CorrelationId { get; set; }
+        public string EndpointName { get; set; }
+        public string MessageTypeName { get; set; }
+        public static Google.Protobuf.Reflection.MessageDescriptor Descriptor { get; }
+        public static Google.Protobuf.MessageParser<NServiceBus.IntegrationTesting.Proto.MessageSkippedMessage> Parser { get; }
+        public int CalculateSize() { }
+        public NServiceBus.IntegrationTesting.Proto.MessageSkippedMessage Clone() { }
+        public bool Equals(NServiceBus.IntegrationTesting.Proto.MessageSkippedMessage other) { }
+        public override bool Equals(object other) { }
+        public override int GetHashCode() { }
+        public void MergeFrom(Google.Protobuf.CodedInputStream input) { }
+        public void MergeFrom(NServiceBus.IntegrationTesting.Proto.MessageSkippedMessage other) { }
         public override string ToString() { }
         public void WriteTo(Google.Protobuf.CodedOutputStream output) { }
     }

--- a/src/NServiceBus.IntegrationTesting.Tests/ScanHelpersTests.cs
+++ b/src/NServiceBus.IntegrationTesting.Tests/ScanHelpersTests.cs
@@ -33,6 +33,9 @@ public class ScanHelpersTests
     static MessageFailedEvent FailureEvent(string correlationId = Id) =>
         new(EndpointName: "EP", Headers: new Dictionary<string, string>(), ExceptionMessage: "boom", CorrelationId: correlationId);
 
+    static MessageSkippedEvent SkipEvent(string correlationId = Id, string messageTypeName = "M") =>
+        new(EndpointName: "EP", MessageTypeName: messageTypeName, CorrelationId: correlationId);
+
     // ── ScanForHandlerEventsAsync ─────────────────────────────────────────────
 
     [Test]
@@ -473,6 +476,101 @@ public class ScanHelpersTests
         ch.Writer.TryWrite(new MessageDispatchedEvent("EP", aqn, "Send", Id));
 
         var result = await TestHostGrpcService.ScanForDispatchEventsAsync(
+            ch.Reader, Id, "M", static all => all.Count >= 1, CancellationToken.None);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Has.Count.EqualTo(1));
+    }
+
+    // ── ScanForSkipEventsAsync ────────────────────────────────────────────────
+
+    [Test]
+    public async Task SkipScan_returns_null_when_channel_closed_without_match()
+    {
+        var ch = Channel.CreateUnbounded<MessageSkippedEvent>();
+        ch.Writer.TryWrite(SkipEvent(correlationId: OtherId));
+        ch.Writer.Complete();
+
+        var result = await TestHostGrpcService.ScanForSkipEventsAsync(
+            ch.Reader, Id, "M", static all => all.Count >= 1, CancellationToken.None);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task SkipScan_returns_null_when_cancelled_before_match()
+    {
+        var ch = Channel.CreateUnbounded<MessageSkippedEvent>();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var result = await TestHostGrpcService.ScanForSkipEventsAsync(
+            ch.Reader, Id, "M", static all => all.Count >= 1, cts.Token);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task SkipScan_ignores_events_with_wrong_correlationId()
+    {
+        var ch = Channel.CreateUnbounded<MessageSkippedEvent>();
+        ch.Writer.TryWrite(SkipEvent(correlationId: OtherId, messageTypeName: "M"));
+        ch.Writer.Complete();
+
+        var result = await TestHostGrpcService.ScanForSkipEventsAsync(
+            ch.Reader, Id, "M", static all => all.Count >= 1, CancellationToken.None);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task SkipScan_ignores_events_with_wrong_messageTypeName()
+    {
+        var ch = Channel.CreateUnbounded<MessageSkippedEvent>();
+        ch.Writer.TryWrite(SkipEvent(correlationId: Id, messageTypeName: "Other"));
+        ch.Writer.Complete();
+
+        var result = await TestHostGrpcService.ScanForSkipEventsAsync(
+            ch.Reader, Id, "M", static all => all.Count >= 1, CancellationToken.None);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public async Task SkipScan_returns_on_first_match()
+    {
+        var ch = Channel.CreateUnbounded<MessageSkippedEvent>();
+        var evt = SkipEvent();
+        ch.Writer.TryWrite(evt);
+
+        var result = await TestHostGrpcService.ScanForSkipEventsAsync(
+            ch.Reader, Id, "M", static all => all.Count >= 1, CancellationToken.None);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result![0], Is.SameAs(evt));
+    }
+
+    [Test]
+    public async Task SkipScan_list_predicate_returns_only_after_n_matches()
+    {
+        var ch = Channel.CreateUnbounded<MessageSkippedEvent>();
+        ch.Writer.TryWrite(SkipEvent());
+        ch.Writer.TryWrite(SkipEvent());
+
+        var result = await TestHostGrpcService.ScanForSkipEventsAsync(
+            ch.Reader, Id, "M", static all => all.Count >= 2, CancellationToken.None);
+
+        Assert.That(result, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public async Task SkipScan_matches_stored_assembly_qualified_name_using_short_name()
+    {
+        const string aqn = "My.NS.M, MyAssembly, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null";
+        var ch = Channel.CreateUnbounded<MessageSkippedEvent>();
+        ch.Writer.TryWrite(new MessageSkippedEvent("EP", aqn, Id));
+
+        var result = await TestHostGrpcService.ScanForSkipEventsAsync(
             ch.Reader, Id, "M", static all => all.Count >= 1, CancellationToken.None);
 
         Assert.That(result, Is.Not.Null);

--- a/src/NServiceBus.IntegrationTesting/ObserveContext.cs
+++ b/src/NServiceBus.IntegrationTesting/ObserveContext.cs
@@ -16,6 +16,7 @@ public sealed class ObserveContext
     readonly List<(string TypeName, Task<IReadOnlyList<HandlerInvokedEvent>> Task)> _handlerTasks = [];
     readonly List<(string TypeName, Task<IReadOnlyList<HandlerInvokedEvent>> Task)> _sagaTasks = [];
     readonly List<(string TypeName, Task<IReadOnlyList<MessageDispatchedEvent>> Task)> _dispatchedTasks = [];
+    readonly List<(string TypeName, Task<IReadOnlyList<MessageSkippedEvent>> Task)> _skippedTasks = [];
     Task<MessageFailedEvent>? _failedTask;
 
     internal ObserveContext(
@@ -128,6 +129,39 @@ public sealed class ObserveContext
     }
 
     /// <summary>
+    /// Wait for the first skip of the named message type at any endpoint.
+    /// </summary>
+    public ObserveContext MessageSkipped(string messageTypeName)
+        => MessageSkipped(messageTypeName, static all => all.Count >= 1);
+
+    /// <summary>
+    /// Wait for skips of the named message type until <paramref name="until"/> returns true.
+    /// The predicate receives the latest event and returns true when done.
+    /// </summary>
+    public ObserveContext MessageSkipped(string messageTypeName, Func<MessageSkippedEvent, bool> until)
+    {
+        ArgumentNullException.ThrowIfNull(until);
+        return MessageSkipped(messageTypeName, all => until(all[^1]));
+    }
+
+    /// <summary>
+    /// Wait for skips of the named message type until <paramref name="until"/> returns true.
+    /// The predicate receives the growing list of matching events (oldest first).
+    /// </summary>
+    public ObserveContext MessageSkipped(string messageTypeName, Func<IReadOnlyList<MessageSkippedEvent>, bool> until)
+    {
+        ArgumentNullException.ThrowIfNull(until);
+        if (_failedTask is not null)
+            throw new InvalidOperationException(
+                "Cannot register MessageSkipped() when MessageFailed() is already registered. " +
+                "Use MessageFailed() alone when the test expects a failure outcome.");
+        _skippedTasks.Add((
+            messageTypeName,
+            _grpcService.WaitForMessageSkipsAsync(_correlationId, messageTypeName, until, _cancellationToken)));
+        return this;
+    }
+
+    /// <summary>
     /// Wait for a message with this correlation ID to be permanently sent to the error queue.
     /// Use this as the sole condition when the test expects a failure outcome.
     /// </summary>
@@ -137,7 +171,7 @@ public sealed class ObserveContext
             throw new InvalidOperationException(
                 "MessageFailed() has already been registered for this ObserveContext.");
 
-        if (_handlerTasks.Count > 0 || _sagaTasks.Count > 0 || _dispatchedTasks.Count > 0)
+        if (_handlerTasks.Count > 0 || _sagaTasks.Count > 0 || _dispatchedTasks.Count > 0 || _skippedTasks.Count > 0)
             throw new InvalidOperationException(
                 "Cannot register MessageFailed() when success conditions are already registered. " +
                 "Use MessageFailed() alone when the test expects a failure outcome.");
@@ -151,14 +185,15 @@ public sealed class ObserveContext
     /// </summary>
     public async Task<ObserveResults> WhenAllAsync()
     {
-        if (_handlerTasks.Count == 0 && _sagaTasks.Count == 0 && _dispatchedTasks.Count == 0 && _failedTask is null)
+        if (_handlerTasks.Count == 0 && _sagaTasks.Count == 0 && _dispatchedTasks.Count == 0 && _skippedTasks.Count == 0 && _failedTask is null)
             throw new InvalidOperationException(
                 "No conditions were registered. Call at least one of HandlerInvoked, SagaInvoked, " +
-                "MessageDispatched, or MessageFailed before awaiting WhenAllAsync.");
+                "MessageDispatched, MessageSkipped, or MessageFailed before awaiting WhenAllAsync.");
 
         IEnumerable<Task> allTasks = _handlerTasks.Select(t => (Task)t.Task)
             .Concat(_sagaTasks.Select(t => (Task)t.Task))
-            .Concat(_dispatchedTasks.Select(t => (Task)t.Task));
+            .Concat(_dispatchedTasks.Select(t => (Task)t.Task))
+            .Concat(_skippedTasks.Select(t => (Task)t.Task));
 
         if (_failedTask is not null)
             allTasks = allTasks.Append(_failedTask);
@@ -169,6 +204,7 @@ public sealed class ObserveContext
             _handlerTasks.ToDictionary(t => t.TypeName, t => t.Task.Result),
             _sagaTasks.ToDictionary(t => t.TypeName, t => t.Task.Result),
             _dispatchedTasks.ToDictionary(t => t.TypeName, t => t.Task.Result),
+            _skippedTasks.ToDictionary(t => t.TypeName, t => t.Task.Result),
             _failedTask?.Result);
     }
 }
@@ -181,17 +217,20 @@ public sealed class ObserveResults
     readonly Dictionary<string, IReadOnlyList<HandlerInvokedEvent>> _handlerResults;
     readonly Dictionary<string, IReadOnlyList<HandlerInvokedEvent>> _sagaResults;
     readonly Dictionary<string, IReadOnlyList<MessageDispatchedEvent>> _dispatchedResults;
+    readonly Dictionary<string, IReadOnlyList<MessageSkippedEvent>> _skippedResults;
     readonly MessageFailedEvent? _failedResult;
 
     internal ObserveResults(
         Dictionary<string, IReadOnlyList<HandlerInvokedEvent>> handlerResults,
         Dictionary<string, IReadOnlyList<HandlerInvokedEvent>> sagaResults,
         Dictionary<string, IReadOnlyList<MessageDispatchedEvent>> dispatchedResults,
+        Dictionary<string, IReadOnlyList<MessageSkippedEvent>> skippedResults,
         MessageFailedEvent? failedResult = null)
     {
         _handlerResults = handlerResults;
         _sagaResults = sagaResults;
         _dispatchedResults = dispatchedResults;
+        _skippedResults = skippedResults;
         _failedResult = failedResult;
     }
 
@@ -245,6 +284,23 @@ public sealed class ObserveResults
     /// </summary>
     public MessageDispatchedEvent MessageDispatched(string messageTypeName)
         => MessageDispatches(messageTypeName).Last();
+
+    /// <summary>
+    /// All collected skips of the named message type satisfying the condition
+    /// registered via ObserveContext.MessageSkipped.
+    /// </summary>
+    public IReadOnlyList<MessageSkippedEvent> MessageSkips(string messageTypeName)
+        => _skippedResults.TryGetValue(messageTypeName, out var list)
+            ? list
+            : throw new InvalidOperationException(
+                $"No MessageSkippedEvents for '{messageTypeName}' were observed.");
+
+    /// <summary>
+    /// The last (or only) skip of the named message type.
+    /// Equivalent to MessageSkips(name).Last() — convenient for the no-arg overload.
+    /// </summary>
+    public MessageSkippedEvent MessageSkipped(string messageTypeName)
+        => MessageSkips(messageTypeName).Last();
 
     /// <summary>
     /// The failure event recorded when a message was permanently sent to the error queue.

--- a/src/NServiceBus.IntegrationTesting/TestHostGrpcService.cs
+++ b/src/NServiceBus.IntegrationTesting/TestHostGrpcService.cs
@@ -70,6 +70,19 @@ public sealed record MessageFailedEvent(
     string CorrelationId);
 
 /// <summary>
+/// Reported when a message is ACKed without invoking any handlers because a
+/// registered <c>SkipRule</c> matched it at the receiving endpoint.
+/// </summary>
+/// <param name="EndpointName">Name of the endpoint that skipped the message.</param>
+/// <param name="MessageTypeName">Full type name of the skipped message.</param>
+/// <param name="CorrelationId">Test correlation ID that ties this skip to a
+/// specific test scenario execution.</param>
+public sealed record MessageSkippedEvent(
+    string EndpointName,
+    string MessageTypeName,
+    string CorrelationId);
+
+/// <summary>
 /// Thrown by WaitFor* methods when the message with the watched correlation ID is
 /// permanently sent to the error queue before the expected event arrives.
 /// Allows tests to fail fast with a descriptive message instead of waiting
@@ -106,6 +119,9 @@ internal sealed class TestHostGrpcService : TestHostService.TestHostServiceBase
 
     readonly object _failedListenersLock = new();
     readonly List<Channel<MessageFailedEvent>> _failedListeners = [];
+
+    readonly object _skippedListenersLock = new();
+    readonly List<Channel<MessageSkippedEvent>> _skippedListeners = [];
 
     /// <summary>
     /// Creates an ObserveContext for the given correlation ID. Add conditions with
@@ -391,6 +407,86 @@ internal sealed class TestHostGrpcService : TestHostService.TestHostServiceBase
     }
 
     /// <summary>
+    /// Convenience overload: returns the first MessageSkippedEvent for the given
+    /// correlation ID and message type name.
+    /// </summary>
+    internal async Task<MessageSkippedEvent> WaitForMessageSkippedAsync(
+        string correlationId,
+        string messageTypeName,
+        CancellationToken cancellationToken = default)
+    {
+        var results = await WaitForMessageSkipsAsync(
+            correlationId, messageTypeName,
+            until: static all => all.Count >= 1,
+            cancellationToken);
+        return results[0];
+    }
+
+    /// <summary>
+    /// Returns a Task that completes when the accumulated MessageSkippedEvents for the
+    /// given correlation ID and message type name satisfy <paramref name="until"/>.
+    /// Races against MessageFailedEvent: if the message is permanently dead before the
+    /// predicate is satisfied, throws MessageFailedException immediately.
+    /// Each call registers an independent listener — safe for concurrent tests.
+    /// </summary>
+    internal async Task<IReadOnlyList<MessageSkippedEvent>> WaitForMessageSkipsAsync(
+        string correlationId,
+        string messageTypeName,
+        Func<IReadOnlyList<MessageSkippedEvent>, bool> until,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(until);
+
+        var skippedChannel = Channel.CreateUnbounded<MessageSkippedEvent>(
+            new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
+        var failureChannel = Channel.CreateUnbounded<MessageFailedEvent>(
+            new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
+
+        lock (_skippedListenersLock)
+            _skippedListeners.Add(skippedChannel);
+        lock (_failedListenersLock)
+            _failedListeners.Add(failureChannel);
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        try
+        {
+            var successTask = ScanForSkipEventsAsync(
+                skippedChannel.Reader, correlationId, messageTypeName, until, cts.Token);
+            var failureTask = ScanForFailureEventAsync(
+                failureChannel.Reader, correlationId, cts.Token);
+
+            await Task.WhenAny(successTask, failureTask);
+            await cts.CancelAsync();
+
+            var skippedResults = await successTask;
+            var failureResult = await failureTask;
+
+            if (failureResult is not null)
+                throw new MessageFailedException(
+                    correlationId, failureResult.Headers, failureResult.ExceptionMessage);
+
+            if (skippedResults is not null)
+                return skippedResults;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new OperationCanceledException(
+                $"Timed out waiting for '{messageTypeName}' skip(s) for correlation '{correlationId}'.",
+                cancellationToken);
+        }
+        finally
+        {
+            lock (_skippedListenersLock)
+                _skippedListeners.Remove(skippedChannel);
+            skippedChannel.Writer.TryComplete();
+
+            lock (_failedListenersLock)
+                _failedListeners.Remove(failureChannel);
+            failureChannel.Writer.TryComplete();
+        }
+    }
+
+    /// <summary>
     /// Instructs the named agent to execute a registered scenario by name.
     /// Returns the correlation ID that ties all events produced by this execution together.
     /// </summary>
@@ -507,6 +603,18 @@ internal sealed class TestHostGrpcService : TestHostService.TestHostServiceBase
                             foreach (var listener in _failedListeners)
                                 listener.Writer.TryWrite(failedEvent);
                         break;
+
+                    case AgentToHostMessage.PayloadOneofCase.MessageSkipped:
+                        var skippedEvt = message.MessageSkipped;
+                        var skippedEvent = new MessageSkippedEvent(
+                            skippedEvt.EndpointName,
+                            skippedEvt.MessageTypeName,
+                            skippedEvt.CorrelationId);
+
+                        lock (_skippedListenersLock)
+                            foreach (var listener in _skippedListeners)
+                                listener.Writer.TryWrite(skippedEvent);
+                        break;
                 }
             }
         }
@@ -619,6 +727,30 @@ internal sealed class TestHostGrpcService : TestHostService.TestHostServiceBase
         CancellationToken cancellationToken)
     {
         var collected = new List<MessageDispatchedEvent>();
+        try
+        {
+            await foreach (var evt in reader.ReadAllAsync(cancellationToken))
+            {
+                if (evt.CorrelationId == correlationId && TypeNameMatches(evt.MessageTypeName, messageTypeName))
+                {
+                    collected.Add(evt);
+                    if (isDone(collected))
+                        return collected;
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        return null;
+    }
+
+    internal static async Task<IReadOnlyList<MessageSkippedEvent>?> ScanForSkipEventsAsync(
+        ChannelReader<MessageSkippedEvent> reader,
+        string correlationId,
+        string messageTypeName,
+        Func<IReadOnlyList<MessageSkippedEvent>, bool> isDone,
+        CancellationToken cancellationToken)
+    {
+        var collected = new List<MessageSkippedEvent>();
         try
         {
             await foreach (var evt in reader.ReadAllAsync(cancellationToken))

--- a/src/proto/testing.proto
+++ b/src/proto/testing.proto
@@ -18,6 +18,7 @@ message AgentToHostMessage {
         HandlerInvokedMessage handler_invoked = 2;
         MessageDispatchedMessage message_dispatched = 3;
         MessageFailedMessage message_failed = 4;
+        MessageSkippedMessage message_skipped = 5;
     }
 }
 
@@ -68,4 +69,10 @@ message MessageFailedMessage {
     string exception_message = 3;
     string correlation_id = 4;
     map<string, string> headers = 5;
+}
+
+message MessageSkippedMessage {
+    string endpoint_name = 1;
+    string message_type_name = 2;
+    string correlation_id = 3;
 }


### PR DESCRIPTION
Closes #74.

- SkipRule.For<T>() and SkipRule.For<T>(predicate) factory methods
- SkipMessageBehavior (IIncomingLogicalMessageContext) short-circuits pipeline and reports MessageSkippedMessage to the test host
- MessageSkippedEvent added to proto; AgentService.ReportMessageSkippedAsync added
- IntegrationTestingBootstrap registers SkipMessageBehavior when skipRules are provided
- ObserveContext.MessageSkipped() (3 overloads), ObserveResults.MessageSkips/MessageSkipped
- Unit tests for ScanForSkipEventsAsync and ObserveResults skip accessors
- docs: document SkipRule in getting-started.md