### PR TITLE
chore: drop net9.0 target — keep LTS-only (net8.0 + net10.0)

### DIFF
--- a/src/NServiceBus.IntegrationTesting.MongoDb/NServiceBus.IntegrationTesting.MongoDb.csproj
+++ b/src/NServiceBus.IntegrationTesting.MongoDb/NServiceBus.IntegrationTesting.MongoDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/NServiceBus.IntegrationTesting.MySql/NServiceBus.IntegrationTesting.MySql.csproj
+++ b/src/NServiceBus.IntegrationTesting.MySql/NServiceBus.IntegrationTesting.MySql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/NServiceBus.IntegrationTesting.PostgreSql/NServiceBus.IntegrationTesting.PostgreSql.csproj
+++ b/src/NServiceBus.IntegrationTesting.PostgreSql/NServiceBus.IntegrationTesting.PostgreSql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/NServiceBus.IntegrationTesting.RabbitMQ/NServiceBus.IntegrationTesting.RabbitMQ.csproj
+++ b/src/NServiceBus.IntegrationTesting.RabbitMQ/NServiceBus.IntegrationTesting.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/NServiceBus.IntegrationTesting.RavenDb/NServiceBus.IntegrationTesting.RavenDb.csproj
+++ b/src/NServiceBus.IntegrationTesting.RavenDb/NServiceBus.IntegrationTesting.RavenDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/NServiceBus.IntegrationTesting.SqlServer/NServiceBus.IntegrationTesting.SqlServer.csproj
+++ b/src/NServiceBus.IntegrationTesting.SqlServer/NServiceBus.IntegrationTesting.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/src/NServiceBus.IntegrationTesting.Tests/NServiceBus.IntegrationTesting.Tests.csproj
+++ b/src/NServiceBus.IntegrationTesting.Tests/NServiceBus.IntegrationTesting.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>

--- a/src/NServiceBus.IntegrationTesting/NServiceBus.IntegrationTesting.csproj
+++ b/src/NServiceBus.IntegrationTesting/NServiceBus.IntegrationTesting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>


### PR DESCRIPTION
.NET 9 STS goes EOL May 2026. Targeting only LTS versions reduces build/CI overhead with no meaningful impact on users.

Fix #357 