### PR TITLE
Add containerBuilder escape hatch to AddEndpoint and expose mapped ports

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1074,7 +1074,7 @@ full NServiceBus headers of the failed message.
 | `.UseMongoDB(containerOptions?, containerBuilder?)` | Starts a MongoDB container; injects `MONGODB_CONNECTION_STRING` |
 | `.UseRavenDB(containerOptions?, containerBuilder?)` | Starts a RavenDB container; injects `RAVENDB_CONNECTION_STRING` |
 | `.UseWireMock()` | Starts embedded WireMock stub server; injects `WIREMOCK_URL` |
-| `.AddEndpoint(name, dockerfile)` | Registers an endpoint container to build and start |
+| `.AddEndpoint(name, dockerfile, containerOptions?, containerBuilder?)` | Registers an endpoint container to build and start |
 | `.WithAgentConnectionTimeout(ts)` | Overrides the 120 s default connection wait |
 | `.StartAsync()` | Builds and starts everything; returns `TestEnvironment` |
 
@@ -1094,6 +1094,8 @@ full NServiceBus headers of the failed message.
 |---|---|
 | `EndpointName` | The logical name of the endpoint |
 | `ExecuteScenarioAsync(name, args?, ct?)` | Triggers a scenario; returns the correlation ID |
+| `GetMappedPort(containerPort)` | Returns the host-side port Testcontainers mapped to `containerPort` |
+| `GetBaseUrl(containerPort, scheme?)` | Returns `{scheme}://localhost:{mappedPort}`; `scheme` defaults to `"http"` |
 
 ### `ObserveContext`
 

--- a/docs/infrastructure-extensibility.md
+++ b/docs/infrastructure-extensibility.md
@@ -166,6 +166,25 @@ as the second argument. It receives the pre-configured builder and must return t
 Because Testcontainers builders are immutable, each `With*` call returns a new instance. The
 callback must return the result of the chain — not just call methods on the input.
 
+The same `containerBuilder` escape hatch is available on `AddEndpoint`. The primary use case
+there is exposing container ports so the test process can query the endpoint over HTTP:
+
+```csharp
+.AddEndpoint("MyEndpoint", "MyEndpoint.Testing/Dockerfile",
+    containerBuilder: b => b.WithPortBinding(8080, assignRandomHostPort: true))
+```
+
+Retrieve the mapped host port after `StartAsync` via `EndpointHandle`:
+
+```csharp
+var baseUrl = _env.GetEndpoint("MyEndpoint").GetBaseUrl(8080);
+// e.g. "http://localhost:52341"
+var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+```
+
+Always use `assignRandomHostPort: true` — fixed host ports cause conflicts when tests run in
+parallel across multiple suites or CI jobs.
+
 `ConnectionStringEnvVarName` is auto-derived from `Key` when left unset (e.g. key `"redis"` →
 `REDIS_CONNECTION_STRING`). Set it explicitly only when you need a name that doesn't follow that
 convention.

--- a/src/NServiceBus.IntegrationTesting.Tests/PublicApiTests.PublicApi_matches_approved_snapshot.verified.txt
+++ b/src/NServiceBus.IntegrationTesting.Tests/PublicApiTests.PublicApi_matches_approved_snapshot.verified.txt
@@ -11,6 +11,8 @@ namespace NServiceBus.IntegrationTesting
     {
         public string EndpointName { get; }
         public System.Threading.Tasks.Task<string> ExecuteScenarioAsync(string scenarioName, System.Collections.Generic.Dictionary<string, string>? args = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public string GetBaseUrl(int containerPort, string scheme = "http") { }
+        public int GetMappedPort(int containerPort) { }
     }
     public sealed class HandlerInvokedEvent : System.IEquatable<NServiceBus.IntegrationTesting.HandlerInvokedEvent>
     {
@@ -98,7 +100,7 @@ namespace NServiceBus.IntegrationTesting
     public sealed class TestEnvironmentBuilder
     {
         public TestEnvironmentBuilder() { }
-        public NServiceBus.IntegrationTesting.TestEnvironmentBuilder AddEndpoint(string endpointName, string dockerfile, System.Action<NServiceBus.IntegrationTesting.EndpointContainerOptions>? containerOptions = null) { }
+        public NServiceBus.IntegrationTesting.TestEnvironmentBuilder AddEndpoint(string endpointName, string dockerfile, System.Action<NServiceBus.IntegrationTesting.EndpointContainerOptions>? containerOptions = null, System.Func<DotNet.Testcontainers.Builders.ContainerBuilder, DotNet.Testcontainers.Builders.ContainerBuilder>? containerBuilder = null) { }
         public System.Threading.Tasks.Task<NServiceBus.IntegrationTesting.TestEnvironment> StartAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public NServiceBus.IntegrationTesting.TestEnvironmentBuilder UseInfrastructure(string key, string defaultEnvVarName, System.Func<DotNet.Testcontainers.Networks.INetwork, DotNet.Testcontainers.Containers.IContainer> buildContainer, string connectionString) { }
         public NServiceBus.IntegrationTesting.TestEnvironmentBuilder UseWireMock(System.Action<NServiceBus.IntegrationTesting.WireMockOptions>? wireMockOptions = null) { }
@@ -112,7 +114,6 @@ namespace NServiceBus.IntegrationTesting
         public string ContainerAddress { get; }
         public int Port { get; }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
-        public NServiceBus.IntegrationTesting.EndpointHandle GetEndpoint(string endpointName) { }
         public NServiceBus.IntegrationTesting.ObserveContext Observe(string correlationId, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task StartAsync() { }
     }

--- a/src/NServiceBus.IntegrationTesting/EndpointHandle.cs
+++ b/src/NServiceBus.IntegrationTesting/EndpointHandle.cs
@@ -1,20 +1,26 @@
+using DotNet.Testcontainers.Containers;
+
 namespace NServiceBus.IntegrationTesting;
 
 /// <summary>
 /// A handle to a named endpoint registered with the test host.
-/// Provides endpoint-scoped operations: waiting for the agent to connect
-/// and executing scenarios.
+/// Provides endpoint-scoped operations: waiting for the agent to connect,
+/// executing scenarios, and resolving host-side mapped ports for any container
+/// ports exposed via the <c>containerBuilder</c> callback on
+/// <see cref="TestEnvironmentBuilder.AddEndpoint"/>.
 /// </summary>
 public sealed class EndpointHandle
 {
     readonly TestHostGrpcService _grpcService;
+    readonly IContainer _container;
 
     public string EndpointName { get; }
 
-    internal EndpointHandle(TestHostGrpcService grpcService, string endpointName)
+    internal EndpointHandle(TestHostGrpcService grpcService, string endpointName, IContainer container)
     {
         _grpcService = grpcService;
         EndpointName = endpointName;
+        _container = container;
     }
 
     /// <summary>
@@ -32,4 +38,24 @@ public sealed class EndpointHandle
         Dictionary<string, string>? args = null,
         CancellationToken cancellationToken = default)
         => _grpcService.ExecuteScenarioAsync(EndpointName, scenarioName, args, cancellationToken);
+
+    /// <summary>
+    /// Returns the host-side port that Testcontainers mapped to
+    /// <paramref name="containerPort"/>. The port must have been declared via
+    /// <c>b.WithPortBinding(<paramref name="containerPort"/>, assignRandomHostPort: true)</c>
+    /// in the <c>containerBuilder</c> callback passed to
+    /// <see cref="TestEnvironmentBuilder.AddEndpoint"/>.
+    /// </summary>
+    public int GetMappedPort(int containerPort)
+        => _container.GetMappedPublicPort(containerPort);
+
+    /// <summary>
+    /// Returns a base URL (<c>{scheme}://localhost:{mappedPort}</c>) for the given
+    /// container port. The port must have been declared via
+    /// <c>b.WithPortBinding(<paramref name="containerPort"/>, assignRandomHostPort: true)</c>
+    /// in the <c>containerBuilder</c> callback passed to
+    /// <see cref="TestEnvironmentBuilder.AddEndpoint"/>.
+    /// </summary>
+    public string GetBaseUrl(int containerPort, string scheme = "http")
+        => $"{scheme}://localhost:{GetMappedPort(containerPort)}";
 }

--- a/src/NServiceBus.IntegrationTesting/TestEnvironment.cs
+++ b/src/NServiceBus.IntegrationTesting/TestEnvironment.cs
@@ -38,7 +38,12 @@ public sealed class TestEnvironment : IAsyncDisposable
 
     /// <summary>Returns a handle to the named endpoint.</summary>
     public EndpointHandle GetEndpoint(string endpointName)
-        => _testHost.GetEndpoint(endpointName);
+    {
+        if (!_endpointContainers.TryGetValue(endpointName, out var container))
+            throw new InvalidOperationException(
+                $"No endpoint named '{endpointName}' was registered.");
+        return new EndpointHandle(_testHost.GrpcService, endpointName, container);
+    }
 
     /// <summary>
     /// Creates an ObserveContext for the given correlation ID. Add conditions with

--- a/src/NServiceBus.IntegrationTesting/TestEnvironmentBuilder.cs
+++ b/src/NServiceBus.IntegrationTesting/TestEnvironmentBuilder.cs
@@ -29,7 +29,8 @@ public sealed class TestEnvironmentBuilder
         Func<INetwork, IContainer> BuildContainer,
         string ConnectionString);
 
-    record EndpointRegistration(string EndpointName, string Dockerfile, EndpointContainerOptions Options);
+    record EndpointRegistration(string EndpointName, string Dockerfile, EndpointContainerOptions Options,
+        Func<ContainerBuilder, ContainerBuilder>? ContainerBuilderCallback);
 
     /// <summary>
     /// Registers a custom infrastructure container. The container is started on the shared
@@ -73,9 +74,18 @@ public sealed class TestEnvironmentBuilder
     /// environment variable names via
     /// <see cref="EndpointContainerOptions.InfrastructureEnvVarNames"/> or to inject
     /// additional static environment variables.
+    /// Use the optional <paramref name="containerBuilder"/> callback to further customize the
+    /// container beyond what <paramref name="containerOptions"/> supports — for example, to
+    /// expose ports via <c>b.WithPortBinding(port, assignRandomHostPort: true)</c>, add volume
+    /// mounts, or set custom wait strategies. Retrieve the mapped host port after
+    /// <see cref="StartAsync"/> via <see cref="EndpointHandle.GetMappedPort"/> or
+    /// <see cref="EndpointHandle.GetBaseUrl"/>.
+    /// Because Testcontainers builders are immutable, the callback must return the result of
+    /// the chain.
     /// </summary>
     public TestEnvironmentBuilder AddEndpoint(string endpointName, string dockerfile,
-        Action<EndpointContainerOptions>? containerOptions = null)
+        Action<EndpointContainerOptions>? containerOptions = null,
+        Func<ContainerBuilder, ContainerBuilder>? containerBuilder = null)
     {
         if (_endpoints.Any(e => e.EndpointName == endpointName))
             throw new ArgumentException(
@@ -83,7 +93,7 @@ public sealed class TestEnvironmentBuilder
 
         var options = new EndpointContainerOptions();
         containerOptions?.Invoke(options);
-        _endpoints.Add(new EndpointRegistration(endpointName, dockerfile, options));
+        _endpoints.Add(new EndpointRegistration(endpointName, dockerfile, options, containerBuilder));
         return this;
     }
 
@@ -173,11 +183,12 @@ public sealed class TestEnvironmentBuilder
             // and the subsequent ExistsWithIdAsync check succeeds, avoiding the BuildKit race
             // condition where the async tagging completes after Testcontainers checks.
             var imageEntries = _endpoints
-                .Select(ep => (ep.EndpointName, ep.Options, Image: new ImageFromDockerfileBuilder()
-                    .WithDockerfileDirectory(_dockerfileDirectory)
-                    .WithDockerfile(ep.Dockerfile)
-                    .WithName($"localhost/nsb-integration-testing/{ep.EndpointName.ToLowerInvariant()}:latest")
-                    .Build()))
+                .Select(ep => (ep.EndpointName, ep.Options, ep.ContainerBuilderCallback,
+                    Image: new ImageFromDockerfileBuilder()
+                        .WithDockerfileDirectory(_dockerfileDirectory)
+                        .WithDockerfile(ep.Dockerfile)
+                        .WithName($"localhost/nsb-integration-testing/{ep.EndpointName.ToLowerInvariant()}:latest")
+                        .Build()))
                 .ToList();
 
             await Task.WhenAll(imageEntries.Select(e => e.Image.CreateAsync(cancellationToken)));
@@ -216,11 +227,12 @@ public sealed class TestEnvironmentBuilder
                     foreach (var (key, value) in e.Options.EnvironmentVariables)
                         envVars[key] = value;
 
-                    return (e.EndpointName, Container: (IContainer)new ContainerBuilder(e.Image.FullName)
+                    var cb = new ContainerBuilder(e.Image.FullName)
                         .WithNetwork(network)
                         .WithEnvironment(envVars)
-                        .WithExtraHost("host.docker.internal", "host-gateway")
-                        .Build());
+                        .WithExtraHost("host.docker.internal", "host-gateway");
+                    return (e.EndpointName,
+                        Container: (IContainer)(e.ContainerBuilderCallback?.Invoke(cb) ?? cb).Build());
                 })
                 .ToList();
 
@@ -231,7 +243,7 @@ public sealed class TestEnvironmentBuilder
             agentCts.CancelAfter(_agentConnectionTimeout);
 
             await Task.WhenAll(_endpoints.Select(ep =>
-                testHost.GetEndpoint(ep.EndpointName).WaitForConnectedAsync(agentCts.Token)));
+                testHost.GrpcService.WaitForAgentAsync(ep.EndpointName, agentCts.Token)));
 
             return new TestEnvironment(
                 testHost,

--- a/src/NServiceBus.IntegrationTesting/TestHostServer.cs
+++ b/src/NServiceBus.IntegrationTesting/TestHostServer.cs
@@ -21,13 +21,6 @@ public sealed class TestHostServer : IAsyncDisposable
     internal TestHostGrpcService GrpcService { get; } = new();
 
     /// <summary>
-    /// Returns a handle for the named endpoint. Use the handle to wait for the agent
-    /// to connect and to execute scenarios.
-    /// </summary>
-    public EndpointHandle GetEndpoint(string endpointName)
-        => new(GrpcService, endpointName);
-
-    /// <summary>
     /// Creates an ObserveContext for the given correlation ID. Add conditions with
     /// HandlerInvoked / MessageDispatched, then call WhenAllAsync() to wait for all of them.
     /// </summary>


### PR DESCRIPTION
- AddEndpoint gains an optional Func<ContainerBuilder, ContainerBuilder>? containerBuilder parameter, consistent with the UseXxx infrastructure methods. Callers can use it to expose ports, add volumes, set custom wait strategies, etc.
- EndpointHandle gains GetMappedPort(containerPort) and GetBaseUrl(containerPort, scheme) to retrieve host-mapped ports after StartAsync, enabling tests to query HTTP endpoints running alongside the NServiceBus endpoint.
- TestEnvironment.GetEndpoint now constructs EndpointHandle directly (threading the IContainer through) instead of delegating to TestHostServer, which no longer needs GetEndpoint.
- Docs and public API snapshot updated accordingly.