### PR TITLE
Add AddContainer for agent-less containers and improve agent connection error

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -994,7 +994,12 @@ public class WhenSomeMessageIsSent
 
 ### Agent does not connect within the timeout
 
-- Increase `WithAgentConnectionTimeout` for slower machines or CI environments.
+When `StartAsync` throws `InvalidOperationException: The following endpoints did not connect within the timeout: 'MyApi'`, check the following:
+
+- **Wrong method**: if the named container does not host an NServiceBus agent (e.g., it is an ASP.NET Web API or a sidecar), register it with `AddContainer()` instead of `AddEndpoint()`. Only `AddEndpoint` waits for an agent connection.
+- **Endpoint name mismatch**: the name passed to `AddEndpoint("Name", ...)` must exactly match the name passed to `IntegrationTestingBootstrap.RunAsync("Name", ...)` in the companion `*.Testing` project's `Program.cs`.
+- **Missing agent bootstrap**: ensure the `*.Testing` project's `Program.cs` calls `IntegrationTestingBootstrap.RunAsync(...)` rather than starting NServiceBus directly.
+- **Slow startup**: increase `WithAgentConnectionTimeout` for slower machines or CI environments.
 - Check that `NSBUS_TESTING_HOST` is not blocked by a firewall rule on the host.
 - Ensure `WithExtraHost("host.docker.internal", "host-gateway")` resolves correctly on Linux Docker Engine (this is applied automatically by `TestEnvironmentBuilder`).
 - Dump the container logs for the failing endpoint to see the startup error:
@@ -1052,7 +1057,8 @@ full NServiceBus headers of the failed message.
 | `.UseMongoDB(containerOptions?, containerBuilder?)` | Starts a MongoDB container; injects `MONGODB_CONNECTION_STRING` |
 | `.UseRavenDB(containerOptions?, containerBuilder?)` | Starts a RavenDB container; injects `RAVENDB_CONNECTION_STRING` |
 | `.UseWireMock()` | Starts embedded WireMock stub server; injects `WIREMOCK_URL` |
-| `.AddEndpoint(name, dockerfile, containerOptions?, containerBuilder?)` | Registers an endpoint container to build and start |
+| `.AddEndpoint(name, dockerfile, containerOptions?, containerBuilder?)` | Registers an NServiceBus endpoint container (with agent); waits for agent connection on startup |
+| `.AddContainer(name, dockerfile, containerOptions?, containerBuilder?)` | Registers any Docker container that does **not** host an NServiceBus agent (e.g., ASP.NET Web APIs, sidecars); participates in the shared network and lifecycle but no agent-connection wait is performed |
 | `.WithAgentConnectionTimeout(ts)` | Overrides the 120 s default connection wait |
 | `.StartAsync()` | Builds and starts everything; returns `TestEnvironment` |
 
@@ -1061,9 +1067,10 @@ full NServiceBus headers of the failed message.
 | Member | Description |
 |---|---|
 | `GetEndpoint(name)` | Returns an `EndpointHandle` for the named endpoint |
+| `GetContainer(name)` | Returns a `ContainerHandle` for a container registered with `AddContainer` |
 | `Observe(correlationId, ct)` | Returns an `ObserveContext` for the given correlation ID |
 | `WireMock` | The embedded `WireMockServer`, or `null` if not configured |
-| `GetEndpointContainerLogsAsync(name)` | Returns `(stdout, stderr)` for the named container |
+| `GetEndpointContainerLogsAsync(name)` | Returns `(stdout, stderr)` for the named endpoint container |
 | `DisposeAsync()` | Stops and disposes all containers and the Docker network |
 
 ### `EndpointHandle`
@@ -1074,6 +1081,17 @@ full NServiceBus headers of the failed message.
 | `ExecuteScenarioAsync(name, args?, ct?)` | Triggers a scenario; returns the correlation ID |
 | `GetMappedPort(containerPort)` | Returns the host-side port Testcontainers mapped to `containerPort` |
 | `GetBaseUrl(containerPort, scheme?)` | Returns `{scheme}://localhost:{mappedPort}`; `scheme` defaults to `"http"` |
+
+### `ContainerHandle`
+
+Returned by `TestEnvironment.GetContainer(name)` for containers registered with `AddContainer`.
+
+| Member | Description |
+|---|---|
+| `Name` | The name this container was registered under |
+| `GetMappedPort(containerPort)` | Returns the host-side port Testcontainers mapped to `containerPort` |
+| `GetBaseUrl(containerPort, scheme?)` | Returns `{scheme}://localhost:{mappedPort}`; `scheme` defaults to `"http"` |
+| `GetLogsAsync()` | Returns `(Stdout, Stderr)` for this container |
 
 ### `ObserveContext`
 

--- a/src/NServiceBus.IntegrationTesting.Tests/PublicApiTests.PublicApi_matches_approved_snapshot.verified.txt
+++ b/src/NServiceBus.IntegrationTesting.Tests/PublicApiTests.PublicApi_matches_approved_snapshot.verified.txt
@@ -1,6 +1,16 @@
 ﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NServiceBus.IntegrationTesting.Tests")]
 namespace NServiceBus.IntegrationTesting
 {
+    public sealed class ContainerHandle
+    {
+        public string Name { get; }
+        public string GetBaseUrl(int containerPort, string scheme = "http") { }
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Stdout",
+                "Stderr"})]
+        public System.Threading.Tasks.Task<System.ValueTuple<string, string>> GetLogsAsync() { }
+        public int GetMappedPort(int containerPort) { }
+    }
     public sealed class EndpointContainerOptions
     {
         public EndpointContainerOptions() { }
@@ -90,6 +100,7 @@ namespace NServiceBus.IntegrationTesting
     {
         public WireMock.Server.WireMockServer? WireMock { get; }
         public System.Threading.Tasks.ValueTask DisposeAsync() { }
+        public NServiceBus.IntegrationTesting.ContainerHandle GetContainer(string name) { }
         public NServiceBus.IntegrationTesting.EndpointHandle GetEndpoint(string endpointName) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Stdout",
@@ -100,6 +111,7 @@ namespace NServiceBus.IntegrationTesting
     public sealed class TestEnvironmentBuilder
     {
         public TestEnvironmentBuilder() { }
+        public NServiceBus.IntegrationTesting.TestEnvironmentBuilder AddContainer(string name, string dockerfile, System.Action<NServiceBus.IntegrationTesting.EndpointContainerOptions>? containerOptions = null, System.Func<DotNet.Testcontainers.Builders.ContainerBuilder, DotNet.Testcontainers.Builders.ContainerBuilder>? containerBuilder = null) { }
         public NServiceBus.IntegrationTesting.TestEnvironmentBuilder AddEndpoint(string endpointName, string dockerfile, System.Action<NServiceBus.IntegrationTesting.EndpointContainerOptions>? containerOptions = null, System.Func<DotNet.Testcontainers.Builders.ContainerBuilder, DotNet.Testcontainers.Builders.ContainerBuilder>? containerBuilder = null) { }
         public System.Threading.Tasks.Task<NServiceBus.IntegrationTesting.TestEnvironment> StartAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public NServiceBus.IntegrationTesting.TestEnvironmentBuilder UseInfrastructure(string key, string defaultEnvVarName, System.Func<DotNet.Testcontainers.Networks.INetwork, DotNet.Testcontainers.Containers.IContainer> buildContainer, string connectionString) { }

--- a/src/NServiceBus.IntegrationTesting/ContainerHandle.cs
+++ b/src/NServiceBus.IntegrationTesting/ContainerHandle.cs
@@ -1,0 +1,48 @@
+using DotNet.Testcontainers.Containers;
+
+namespace NServiceBus.IntegrationTesting;
+
+/// <summary>
+/// A handle to a named container registered with <see cref="TestEnvironmentBuilder.AddContainer"/>.
+/// Provides port-mapping and log helpers for containers that do not host an NServiceBus agent.
+/// </summary>
+public sealed class ContainerHandle
+{
+    readonly IContainer _container;
+
+    /// <summary>The name this container was registered under.</summary>
+    public string Name { get; }
+
+    internal ContainerHandle(string name, IContainer container)
+    {
+        Name = name;
+        _container = container;
+    }
+
+    /// <summary>
+    /// Returns the host-side port that Testcontainers mapped to
+    /// <paramref name="containerPort"/>. The port must have been declared via
+    /// <c>b.WithPortBinding(<paramref name="containerPort"/>, assignRandomHostPort: true)</c>
+    /// in the <c>containerBuilder</c> callback passed to
+    /// <see cref="TestEnvironmentBuilder.AddContainer"/>.
+    /// </summary>
+    public int GetMappedPort(int containerPort)
+        => _container.GetMappedPublicPort(containerPort);
+
+    /// <summary>
+    /// Returns a base URL (<c>{scheme}://localhost:{mappedPort}</c>) for the given
+    /// container port. The port must have been declared via
+    /// <c>b.WithPortBinding(<paramref name="containerPort"/>, assignRandomHostPort: true)</c>
+    /// in the <c>containerBuilder</c> callback passed to
+    /// <see cref="TestEnvironmentBuilder.AddContainer"/>.
+    /// </summary>
+    public string GetBaseUrl(int containerPort, string scheme = "http")
+        => $"{scheme}://localhost:{GetMappedPort(containerPort)}";
+
+    /// <summary>
+    /// Returns the stdout and stderr of this container.
+    /// Useful for dumping diagnostic output when a test fails.
+    /// </summary>
+    public Task<(string Stdout, string Stderr)> GetLogsAsync()
+        => _container.GetLogsAsync();
+}

--- a/src/NServiceBus.IntegrationTesting/TestEnvironment.cs
+++ b/src/NServiceBus.IntegrationTesting/TestEnvironment.cs
@@ -14,19 +14,22 @@ public sealed class TestEnvironment : IAsyncDisposable
     readonly INetwork _network;
     readonly IReadOnlyList<IContainer> _infraContainers;
     readonly Dictionary<string, IContainer> _endpointContainers;
+    readonly Dictionary<string, IContainer> _containers;
 
     internal TestEnvironment(
         TestHostServer testHost,
         INetwork network,
         WireMockServer? wireMock,
         IReadOnlyList<IContainer> infraContainers,
-        Dictionary<string, IContainer> endpointContainers)
+        Dictionary<string, IContainer> endpointContainers,
+        Dictionary<string, IContainer> containers)
     {
         _testHost = testHost;
         _network = network;
         WireMock = wireMock;
         _infraContainers = infraContainers;
         _endpointContainers = endpointContainers;
+        _containers = containers;
     }
 
     /// <summary>
@@ -43,6 +46,19 @@ public sealed class TestEnvironment : IAsyncDisposable
             throw new InvalidOperationException(
                 $"No endpoint named '{endpointName}' was registered.");
         return new EndpointHandle(_testHost.GrpcService, endpointName, container);
+    }
+
+    /// <summary>
+    /// Returns a handle to the named container registered with
+    /// <see cref="TestEnvironmentBuilder.AddContainer"/>.
+    /// </summary>
+    public ContainerHandle GetContainer(string name)
+    {
+        if (!_containers.TryGetValue(name, out var container))
+            throw new InvalidOperationException(
+                $"No container named '{name}' was registered. " +
+                "Use AddContainer() to register agent-less containers.");
+        return new ContainerHandle(name, container);
     }
 
     /// <summary>
@@ -72,6 +88,9 @@ public sealed class TestEnvironment : IAsyncDisposable
     {
         await Task.WhenAll(_endpointContainers.Values.Select(c => c.StopAsync()));
         await Task.WhenAll(_endpointContainers.Values.Select(c => c.DisposeAsync().AsTask()));
+
+        await Task.WhenAll(_containers.Values.Select(c => c.StopAsync()));
+        await Task.WhenAll(_containers.Values.Select(c => c.DisposeAsync().AsTask()));
 
         await _testHost.DisposeAsync();
 

--- a/src/NServiceBus.IntegrationTesting/TestEnvironmentBuilder.cs
+++ b/src/NServiceBus.IntegrationTesting/TestEnvironmentBuilder.cs
@@ -22,6 +22,7 @@ public sealed class TestEnvironmentBuilder
 
     readonly List<InfrastructureDeclaration> _infrastructure = [];
     readonly List<EndpointRegistration> _endpoints = [];
+    readonly List<ContainerRegistration> _containers = [];
 
     record InfrastructureDeclaration(
         string Key,
@@ -30,6 +31,9 @@ public sealed class TestEnvironmentBuilder
         string ConnectionString);
 
     record EndpointRegistration(string EndpointName, string Dockerfile, EndpointContainerOptions Options,
+        Func<ContainerBuilder, ContainerBuilder>? ContainerBuilderCallback);
+
+    record ContainerRegistration(string Name, string Dockerfile, EndpointContainerOptions Options,
         Func<ContainerBuilder, ContainerBuilder>? ContainerBuilderCallback);
 
     /// <summary>
@@ -135,13 +139,40 @@ public sealed class TestEnvironmentBuilder
         Action<EndpointContainerOptions>? containerOptions = null,
         Func<ContainerBuilder, ContainerBuilder>? containerBuilder = null)
     {
-        if (_endpoints.Any(e => e.EndpointName == endpointName))
+        if (_endpoints.Any(e => e.EndpointName == endpointName) ||
+            _containers.Any(c => c.Name == endpointName))
             throw new ArgumentException(
                 $"An endpoint named '{endpointName}' has already been added.", nameof(endpointName));
 
         var options = new EndpointContainerOptions();
         containerOptions?.Invoke(options);
         _endpoints.Add(new EndpointRegistration(endpointName, dockerfile, options, containerBuilder));
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a container that participates in the test environment (same Docker network,
+    /// same lifecycle) but does not host an NServiceBus agent. Use this for non-NServiceBus
+    /// services such as ASP.NET Web APIs, sidecars, or other dependencies that your endpoints
+    /// communicate with during tests. Access the running container via
+    /// <see cref="TestEnvironment.GetContainer"/>.
+    /// <para>
+    /// Unlike <see cref="AddEndpoint"/>, no agent-connection wait is performed for containers
+    /// registered with this method.
+    /// </para>
+    /// </summary>
+    public TestEnvironmentBuilder AddContainer(string name, string dockerfile,
+        Action<EndpointContainerOptions>? containerOptions = null,
+        Func<ContainerBuilder, ContainerBuilder>? containerBuilder = null)
+    {
+        if (_containers.Any(c => c.Name == name) ||
+            _endpoints.Any(e => e.EndpointName == name))
+            throw new ArgumentException(
+                $"A container named '{name}' has already been added.", nameof(name));
+
+        var options = new EndpointContainerOptions();
+        containerOptions?.Invoke(options);
+        _containers.Add(new ContainerRegistration(name, dockerfile, options, containerBuilder));
         return this;
     }
 
@@ -189,7 +220,7 @@ public sealed class TestEnvironmentBuilder
         List<IContainer> infraContainers = [];
         TestHostServer? testHost = null;
         WireMockServer? wireMock = null;
-        List<(string EndpointName, IContainer Container)> containerEntries = [];
+        List<(string Name, bool HasAgent, IContainer Container)> containerEntries = [];
 
         try
         {
@@ -231,11 +262,16 @@ public sealed class TestEnvironmentBuilder
             // and the subsequent ExistsWithIdAsync check succeeds, avoiding the BuildKit race
             // condition where the async tagging completes after Testcontainers checks.
             var imageEntries = _endpoints
-                .Select(ep => (ep.EndpointName, ep.Options, ep.ContainerBuilderCallback,
+                .Select(ep => (Name: ep.EndpointName, ep.Options, ep.ContainerBuilderCallback,
+                    HasAgent: true, ep.Dockerfile))
+                .Concat(_containers
+                    .Select(c => (Name: c.Name, c.Options, c.ContainerBuilderCallback,
+                        HasAgent: false, c.Dockerfile)))
+                .Select(r => (r.Name, r.Options, r.ContainerBuilderCallback, r.HasAgent,
                     Image: new ImageFromDockerfileBuilder()
                         .WithDockerfileDirectory(_dockerfileDirectory)
-                        .WithDockerfile(ep.Dockerfile)
-                        .WithName($"localhost/nsb-integration-testing/{ep.EndpointName.ToLowerInvariant()}:latest")
+                        .WithDockerfile(r.Dockerfile)
+                        .WithName($"localhost/nsb-integration-testing/{r.Name.ToLowerInvariant()}:latest")
                         .Build()))
                 .ToList();
 
@@ -279,7 +315,7 @@ public sealed class TestEnvironmentBuilder
                         .WithNetwork(network)
                         .WithEnvironment(envVars)
                         .WithExtraHost("host.docker.internal", "host-gateway");
-                    return (e.EndpointName,
+                    return (e.Name, e.HasAgent,
                         Container: (IContainer)(e.ContainerBuilderCallback?.Invoke(cb) ?? cb).Build());
                 })
                 .ToList();
@@ -290,21 +326,52 @@ public sealed class TestEnvironmentBuilder
             using var agentCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             agentCts.CancelAfter(_agentConnectionTimeout);
 
-            await Task.WhenAll(_endpoints.Select(ep =>
-                testHost.GrpcService.WaitForAgentAsync(ep.EndpointName, agentCts.Token)));
+            var agentWaitTasks = _endpoints
+                .Select(async ep =>
+                {
+                    bool connected;
+                    try
+                    {
+                        await testHost.GrpcService.WaitForAgentAsync(ep.EndpointName, agentCts.Token);
+                        connected = true;
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        connected = false;
+                    }
+                    return (ep.EndpointName, connected);
+                })
+                .ToList();
+
+            var agentResults = await Task.WhenAll(agentWaitTasks);
+            var notConnected = agentResults
+                .Where(r => !r.connected)
+                .Select(r => r.EndpointName)
+                .ToList();
+
+            if (notConnected.Count > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                throw new InvalidOperationException(
+                    $"The following endpoints did not connect within the {_agentConnectionTimeout} timeout: " +
+                    $"{string.Join(", ", notConnected.Select(n => $"'{n}'"))}. " +
+                    "If any of these containers do not host an NServiceBus agent, " +
+                    "use AddContainer() instead of AddEndpoint().");
+            }
 
             return new TestEnvironment(
                 testHost,
                 network,
                 wireMock,
                 infraContainers,
-                containerEntries.ToDictionary(e => e.EndpointName, e => e.Container));
+                containerEntries.Where(e => e.HasAgent).ToDictionary(e => e.Name, e => e.Container),
+                containerEntries.Where(e => !e.HasAgent).ToDictionary(e => e.Name, e => e.Container));
         }
         catch
         {
             // Best-effort cleanup: attempt each disposal independently so a failure in
             // one step does not prevent the remaining resources from being released.
-            foreach (var (_, container) in containerEntries)
+            foreach (var (_, _, container) in containerEntries)
             {
                 try { await container.StopAsync(); } catch { }
                 try { await container.DisposeAsync(); } catch { }


### PR DESCRIPTION
- AddContainer(name, dockerfile, options?, containerBuilder?) registers any Docker container that does not host an NServiceBus agent (e.g. ASP.NET Web APIs, sidecars); participates in shared network and lifecycle, no agent wait
- TestEnvironment.GetContainer(name) returns a ContainerHandle with GetMappedPort, GetBaseUrl, and GetLogsAsync
- When AddEndpoint agents do not connect within the timeout, throw InvalidOperationException naming the unresponsive endpoints and suggesting AddContainer() if the container has no agent, instead of a generic OperationCanceledException
- Updated public API snapshot and getting-started docs